### PR TITLE
Expand plan with advanced task and planning features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-# hello-world
+# Task Timeboxing App
 
-Yo Mamas and Papas. Not sure what I am doing but maybe I'll figure it out someday :)
+This project aims to build a single-user web app for managing tasks, prioritizing them, and timeboxing into a calendar with Google Calendar and iCal integration. It also includes guided daily/weekly planning, focus/playlist sessions, imports, and auto-scheduling to fit work inside user-defined hours.
+
+## Documentation
+- Product requirements: `docs/product/requirements.md`
+- Data model: `docs/tech/data-model.md`
+- Architecture: `docs/tech/architecture.md`
+- Calendar integration: `docs/tech/calendar.md`
+- MVP milestones: `docs/project/milestones.md`

--- a/docs/product/requirements.md
+++ b/docs/product/requirements.md
@@ -1,0 +1,34 @@
+# Product Requirements
+
+## Target
+- Single-user web app.
+- Manages the user's own calendar while integrating with Google Calendar and iCal feeds.
+
+## Core user stories
+- As a user, I can create and edit tasks quickly via button, keyboard shortcut, or a global command palette; I can also import tasks from connected tools/calendars into backlogs.
+- As a user, I can set priority on tasks using weighted levels and sort by it.
+- As a user, I can estimate duration, planned time, and due dates so scheduling is realistic.
+- As a user, I can add rich notes, subtasks, and channels/contexts for grouping, privacy, or routing to specific calendars.
+- As a user, I can timebox tasks by dragging them into a calendar view and resizing blocks; tasks can be scheduled in multiple blocks and moved easily.
+- As a user, I can see conflicts between time blocks and resolve or auto-reschedule them within my working hours.
+- As a user, I can run focus sessions with timers that log actual time and update task progress.
+- As a user, I can set tasks to recur on specific days and have unfinished tasks roll over automatically at midnight while keeping logged time.
+- As a user, I can sync scheduled blocks to my primary calendar and see updates pulled from Google Calendar/iCal; I can temporarily pause sync or disconnect a provider.
+
+## Planning rituals and views
+- Guided daily planning ritual prompts me (morning or evening) to review yesterday, pull meetings, select backlog tasks, defer non-essential work, and order my day.
+- I can run multiple planning sessions per day (e.g., work and personal) and trigger an evening planning mode after 3 p.m.
+- I can mark daily highlights (top priorities) and set weekly objectives with a weekly review to reflect and adjust.
+- I can navigate across Today, daily, weekly, backlog, archive, and calendar views; a focus mode and focus bar keep the current task visible.
+- I can schedule breaks between tasks with defaults and reminders.
+
+## Non-functional requirements
+- OAuth for Google Calendar; token storage must be encrypted at rest.
+- Sync latency target: under 2 minutes for new or updated blocks when polling; webhook updates should be near-real-time where supported.
+- Offline tolerance: cache last task list and allow drafts that sync when back online.
+- Notifications for upcoming blocks, failed syncs, daily/weekly digests, and planning reminders (morning or evening).
+
+## Success metrics
+- Time-to-first-schedule under 3 minutes for a new user.
+- 90% of sync attempts succeed without user intervention.
+- Drag-and-drop scheduling latency under 150 ms frame budget.

--- a/docs/project/milestones.md
+++ b/docs/project/milestones.md
@@ -1,0 +1,8 @@
+# MVP Milestones
+
+1. **Foundations**: Set up repo, linting, formatting, CI, and database schema with Prisma migrations; add Redis for jobs/timers.
+2. **Task CRUD + Import**: Implement task endpoints, weighted priority scoring, list filtering/sorting UI, keyboard shortcuts/command palette, and basic import reviewer.
+3. **Timeboxing UI + Channels**: Add calendar view with drag-and-drop blocks, conflict detection, multi-block scheduling, channel assignments, and block CRUD.
+4. **Planning rituals + Focus**: Guided daily/weekly planning flows, daily highlights, weekly objectives, focus/playlist mode with timers, breaks, and rollover for unfinished tasks.
+5. **Calendar sync + Auto-schedule**: Google OAuth connect/disconnect, webhook handling, polling fallback, bidirectional updates, auto-scheduling/rescheduling within working hours, and channel-to-calendar mapping.
+6. **Polish + Observability**: Notifications/digests, audit logs, telemetry events, performance tuning, and accessibility/keyboard coverage.

--- a/docs/tech/architecture.md
+++ b/docs/tech/architecture.md
@@ -1,0 +1,31 @@
+# Architecture Outline
+
+## Stack choice
+- **Frontend**: React + TypeScript (consider Next.js for SSR), using a drag-and-drop library for scheduling and a calendar component (e.g., FullCalendar). Command palette (Ctrl/Cmd+K) powered by a headless command framework.
+- **Backend**: Node.js + Express with PostgreSQL. Prisma for schema and migrations. Background workers via BullMQ/Redis.
+- **Auth**: Email + magic link for single-user simplicity; OAuth 2.0 for Google Calendar to obtain calendar scopes.
+- **Deployment**: Frontend on Vercel/Netlify; backend on Fly.io/Render with managed PostgreSQL and Redis for jobs/timers.
+
+## API surface
+- `POST /tasks` create task; `GET /tasks` list with filters (scheduled/unscheduled, channel, status); `PATCH /tasks/:id` update; `DELETE /tasks/:id` archive/delete.
+- `POST /tasks/:id/priority` update importance/urgency and recompute score.
+- `POST /tasks/import` bulk import tasks from external tools/calendars; `GET /tasks/imports` review proposed imports.
+- `POST /tasks/:id/subtasks` create subtask; `PATCH /subtasks/:id` update order/status.
+- `POST /tasks/:id/recurrence` create/update recurrence rules; `POST /tasks/:id/rollover` force-roll unfinished work.
+- `POST /timeblocks` create block; `PATCH /timeblocks/:id` update timing/status; `DELETE /timeblocks/:id` remove block.
+- `POST /timeblocks/:id/confirm` mark as confirmed and sync to calendar; `POST /timeblocks/:id/suggest` auto-schedule within working hours.
+- `POST /planning-sessions` start/complete daily/weekly planning; `POST /objectives` create weekly objectives; `POST /highlights` set daily highlights.
+- `POST /focus-sessions` start/stop a focus timer and log actual_minutes; `POST /breaks` schedule breaks with reminders.
+- `POST /sync/providers/google/connect` start OAuth; `POST /sync/providers/google/disconnect` revoke; `POST /sync/providers/google/webhook` receive pushes.
+
+## Background jobs
+- Poll Google Calendar for changes when webhooks are not available; backoff on errors.
+- Reconcile conflicts by comparing app state vs. external changes and creating user-visible alerts.
+- Nightly cleanup of expired tokens, rollover unfinished tasks at midnight, and archival of completed tasks beyond retention window.
+- Auto-scheduling/rescheduling within working hours when conflicts are detected or when the user requests suggestions.
+- Daily/weekly digests and planning reminders (respect morning/evening preferences).
+- Import syncers to pull tasks from integrated tools and propose imports.
+
+## Telemetry and logging
+- Emit events for task created, priority updated, block scheduled, block completed, sync success/failure, focus session completed, recurrence/rollover applied, and planning session completed.
+- Centralized structured logs; trace IDs propagated through API and jobs.

--- a/docs/tech/calendar.md
+++ b/docs/tech/calendar.md
@@ -1,0 +1,32 @@
+# Calendar Integration Strategy
+
+## Providers
+- **Google Calendar**: OAuth 2.0 with incremental scopes (`https://www.googleapis.com/auth/calendar.events`). Prefer watch/webhook channels; fall back to polling if channel expires.
+- **iCal**: Ingest via subscribed feed URL; outbound sync limited to read-only unless paired with CalDAV provider.
+- **Channels/contexts**: Map channels to calendars; private channels stay local, shared channels push to their mapped provider calendar when available.
+
+## OAuth flow (Google)
+1. User starts connect flow; redirect to Google OAuth with calendar scope and offline access.
+2. Store authorization code exchange result (access + refresh token) encrypted in the database; attach to `CalendarIntegration` row.
+3. On success, fetch calendar list and select primary by default; allow user override.
+4. Start a watch channel on the chosen calendar; persist channel ID and expiry in sync_state.
+
+## Sync cadence
+- **Webhooks**: Handle `POST /sync/providers/google/webhook` to ingest notifications; fetch changes using sync tokens.
+- **Polling fallback**: Poll every 2 minutes when webhook is unavailable or expired; exponential backoff on failures.
+- **iCal refresh**: Re-fetch feed every 15 minutes or when user requests manual refresh.
+- **Task rollover**: Nightly job (local midnight) creates a new instance of unfinished tasks with carried-over actual time and re-schedules blocks into the next working day.
+
+## Conflict resolution
+- Use `etag`/`updated` fields to detect changes; last-write from the external calendar creates an in-app alert before overwriting.
+- If a time block was moved externally, update local `TimeBlock` and mark as `tentative` with a banner prompting the user to confirm.
+- Auto-rescheduler proposes new slots within working hours when conflicts or collisions are detected; user can accept to update event times.
+
+## Auto-scheduling and focus
+- Auto-scheduling service uses working hours, calendar availability, and task priority/estimated time to suggest blocks; supports multi-block scheduling for large tasks.
+- Playlist/focus mode walks through scheduled tasks sequentially, starting focus timers and updating actual_minutes; pushes event updates on overruns.
+
+## Error handling
+- Auto-retry transient HTTP 5xx/429 with jittered backoff.
+- On 401/invalid grant, mark integration as `reconnect_required` and notify the user; allow manual reconnect.
+- Log webhook verification failures and ignore unverified payloads.

--- a/docs/tech/data-model.md
+++ b/docs/tech/data-model.md
@@ -1,0 +1,27 @@
+# Data Model
+
+## Entities
+- **User**: id, email, display_name, settings (time zone, working hours), onboarding_state.
+- **Task**: id, user_id (FK), title, rich_notes, status (todo/in-progress/done), priority_score, priority_level (1-5), due_at, planned_minutes, estimated_minutes, actual_minutes, channel_id (FK), planned_sessions (array of planning_session_id), recurrence_rule (RRULE), rollover_state (carried_from_date, rolled_minutes), labels (array), created_at, updated_at.
+- **Subtask**: id, task_id (FK), title, status, order, created_at, updated_at.
+- **TaskImport**: id, user_id (FK), source (calendar/tool), source_ref, payload (JSONB), task_id (FK nullable until accepted), state (proposed/accepted/ignored), created_at.
+- **TimeBlock**: id, user_id (FK), task_id (FK, nullable for unscheduled blocks), start_at, end_at, status (tentative/confirmed/completed/cancelled), location, notes, calendar_event_id, provider (google/ical/local), recurrence_rule (optional), created_at, updated_at.
+- **Channel**: id, user_id (FK), name, visibility (private/shared), target_calendar_id (nullable), color, created_at, updated_at.
+- **PlanningSession**: id, user_id (FK), type (morning/evening/weekly/custom), started_at, completed_at, context (work/personal), source (auto/manual), notes.
+- **Objective**: id, user_id (FK), type (weekly/objective), title, description, target_week, status, created_at, updated_at.
+- **FocusSession**: id, user_id (FK), task_id (FK), start_at, end_at, planned_minutes, actual_minutes, status (active/completed/cancelled), interruptions (JSONB), created_at.
+- **CalendarIntegration**: id, user_id (FK), provider (google/ical), access_token, refresh_token, expires_at, sync_state (last_sync_at, cursor), sync_mode (polling/webhook), calendar_id.
+- **AuditLog**: id, user_id (FK), action, entity_type, entity_id, metadata (JSONB), created_at.
+
+## Prioritization
+- Priority levels: 1 (lowest) to 5 (highest); default is 3.
+- Suggested weighted score: `priority_score = (importance * 0.6) + (urgency * 0.4)`, both on a 1-5 scale.
+- Sorting defaults to priority_score desc, then due_at asc; backlog auto-sorts by scheduled start if timeboxed.
+
+## Indexing
+- Tasks: indexes on (user_id, status), (user_id, priority_score desc), (user_id, due_at), (user_id, channel_id), and GIN on labels for filtering.
+- Subtasks: (task_id, order).
+- TimeBlocks: indexes on (user_id, start_at, end_at) to surface conflicts quickly.
+- PlanningSession: (user_id, started_at desc) for ritual history.
+- FocusSession: (user_id, start_at desc) to show recent focus work.
+- CalendarIntegration: index on (user_id, provider) for lookups during sync.


### PR DESCRIPTION
## Summary
- broaden product requirements to cover imports, channels, recurrence/rollover, rituals, and focus/playlist flows
- extend data model, architecture, and calendar strategy for auto-scheduling, planning sessions, and command palette support
- update milestones and README to reflect richer feature set and scheduling automation

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693acfd1680083319ab3104b35029181)