### PR TITLE
Add Prisma schema, migration, and seed data

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,28 @@
+# Backend
+
+## Database setup
+The service uses PostgreSQL via Prisma. Provide a connection string in `DATABASE_URL`, for example:
+
+```
+DATABASE_URL="postgresql://user:password@localhost:5432/app_db?schema=public"
+```
+
+## Migrations and schema
+Prisma metadata lives in `prisma/schema.prisma`, with the initial migration under `prisma/migrations/0001_init`.
+
+Common commands:
+
+- Generate the Prisma client after schema changes:
+  ```
+  npm run db:generate --workspace backend
+  ```
+- Create and apply migrations (requires a reachable database):
+  ```
+  npm run db:migrate --workspace backend
+  ```
+- Seed the development database with a default user and sample data:
+  ```
+  npm run db:seed --workspace backend
+  ```
+
+If you prefer to scope commands to the backend directory instead of workspaces, run them from `backend/` without the `--workspace` flag.

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,9 +10,13 @@
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
     "type-check": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "db:migrate": "prisma migrate dev",
+    "db:generate": "prisma generate",
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
+    "@prisma/client": "^5.22.0",
     "express": "^4.19.2"
   },
   "devDependencies": {
@@ -23,6 +27,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.3.3",
+    "prisma": "^5.22.0",
     "supertest": "^6.3.4",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",

--- a/backend/prisma/migrations/0001_init/migration.sql
+++ b/backend/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,188 @@
+-- Create required extension for UUID generation
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Enum definitions
+CREATE TYPE "TaskStatus" AS ENUM ('todo', 'in_progress', 'done');
+CREATE TYPE "TaskImportState" AS ENUM ('proposed', 'accepted', 'ignored');
+CREATE TYPE "TimeBlockStatus" AS ENUM ('tentative', 'confirmed', 'completed', 'cancelled');
+CREATE TYPE "ChannelVisibility" AS ENUM ('private', 'shared');
+CREATE TYPE "PlanningSessionType" AS ENUM ('morning', 'evening', 'weekly', 'custom');
+CREATE TYPE "PlanningContext" AS ENUM ('work', 'personal');
+CREATE TYPE "PlanningSource" AS ENUM ('auto', 'manual');
+CREATE TYPE "FocusSessionStatus" AS ENUM ('active', 'completed', 'cancelled');
+CREATE TYPE "SyncMode" AS ENUM ('polling', 'webhook');
+CREATE TYPE "Provider" AS ENUM ('google', 'ical', 'local');
+
+-- User table
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "email" TEXT NOT NULL UNIQUE,
+    "display_name" TEXT NOT NULL,
+    "settings" JSONB,
+    "onboarding_state" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Channel table
+CREATE TABLE "Channel" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "visibility" "ChannelVisibility" NOT NULL DEFAULT 'private',
+    "target_calendar_id" TEXT,
+    "color" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Channel_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Task table
+CREATE TABLE "Task" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "rich_notes" TEXT,
+    "status" "TaskStatus" NOT NULL DEFAULT 'todo',
+    "priority_score" DOUBLE PRECISION,
+    "priority_level" INTEGER NOT NULL DEFAULT 3,
+    "due_at" TIMESTAMPTZ,
+    "planned_minutes" INTEGER,
+    "estimated_minutes" INTEGER,
+    "actual_minutes" INTEGER,
+    "channel_id" TEXT,
+    "planned_sessions" TEXT[] NOT NULL DEFAULT '{}',
+    "recurrence_rule" TEXT,
+    "rollover_state" JSONB,
+    "labels" TEXT[] NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Task_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Task_channel_id_fkey" FOREIGN KEY ("channel_id") REFERENCES "Channel"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- Subtask table
+CREATE TABLE "Subtask" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "task_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "status" "TaskStatus" NOT NULL DEFAULT 'todo',
+    "order" INTEGER NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Subtask_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Task import table
+CREATE TABLE "TaskImport" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "source_ref" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "task_id" TEXT,
+    "state" "TaskImportState" NOT NULL DEFAULT 'proposed',
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "TaskImport_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "TaskImport_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- Time block table
+CREATE TABLE "TimeBlock" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "task_id" TEXT,
+    "start_at" TIMESTAMPTZ NOT NULL,
+    "end_at" TIMESTAMPTZ NOT NULL,
+    "status" "TimeBlockStatus" NOT NULL DEFAULT 'tentative',
+    "location" TEXT,
+    "notes" TEXT,
+    "calendar_event_id" TEXT,
+    "provider" "Provider" NOT NULL,
+    "recurrence_rule" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "TimeBlock_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "TimeBlock_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- Planning session table
+CREATE TABLE "PlanningSession" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "type" "PlanningSessionType" NOT NULL,
+    "started_at" TIMESTAMPTZ NOT NULL,
+    "completed_at" TIMESTAMPTZ,
+    "context" "PlanningContext" NOT NULL,
+    "source" "PlanningSource" NOT NULL,
+    "notes" TEXT,
+    CONSTRAINT "PlanningSession_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Objective table
+CREATE TABLE "Objective" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "target_week" TIMESTAMPTZ,
+    "status" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Objective_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Focus session table
+CREATE TABLE "FocusSession" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "task_id" TEXT NOT NULL,
+    "start_at" TIMESTAMPTZ NOT NULL,
+    "end_at" TIMESTAMPTZ NOT NULL,
+    "planned_minutes" INTEGER NOT NULL,
+    "actual_minutes" INTEGER,
+    "status" "FocusSessionStatus" NOT NULL DEFAULT 'active',
+    "interruptions" JSONB,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FocusSession_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "FocusSession_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Calendar integration table
+CREATE TABLE "CalendarIntegration" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "provider" "Provider" NOT NULL,
+    "access_token" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "expires_at" TIMESTAMPTZ,
+    "sync_state" JSONB,
+    "sync_mode" "SyncMode" NOT NULL DEFAULT 'polling',
+    "calendar_id" TEXT,
+    CONSTRAINT "CalendarIntegration_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Audit log table
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "entity_type" TEXT NOT NULL,
+    "entity_id" TEXT NOT NULL,
+    "metadata" JSONB,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AuditLog_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Indexes
+CREATE INDEX "Task_user_status_idx" ON "Task"("user_id", "status");
+CREATE INDEX "Task_user_priority_score_idx" ON "Task"("user_id", "priority_score" DESC);
+CREATE INDEX "Task_user_due_idx" ON "Task"("user_id", "due_at");
+CREATE INDEX "Task_user_channel_idx" ON "Task"("user_id", "channel_id");
+CREATE INDEX "Task_labels_gin" ON "Task" USING GIN ("labels");
+CREATE INDEX "Subtask_task_order_idx" ON "Subtask"("task_id", "order");
+CREATE INDEX "TimeBlock_user_time_idx" ON "TimeBlock"("user_id", "start_at", "end_at");
+CREATE INDEX "PlanningSession_user_started_idx" ON "PlanningSession"("user_id", "started_at" DESC);
+CREATE INDEX "FocusSession_user_started_idx" ON "FocusSession"("user_id", "start_at" DESC);
+CREATE INDEX "CalendarIntegration_user_provider_idx" ON "CalendarIntegration"("user_id", "provider");

--- a/backend/prisma/migrations/migration_lock.toml
+++ b/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,254 @@
+// Prisma schema describing the planning and scheduling entities
+// See docs/tech/data-model.md for field descriptions.
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum TaskStatus {
+  todo
+  in_progress
+  done
+}
+
+enum TaskImportState {
+  proposed
+  accepted
+  ignored
+}
+
+enum TimeBlockStatus {
+  tentative
+  confirmed
+  completed
+  cancelled
+}
+
+enum ChannelVisibility {
+  private
+  shared
+}
+
+enum PlanningSessionType {
+  morning
+  evening
+  weekly
+  custom
+}
+
+enum PlanningContext {
+  work
+  personal
+}
+
+enum PlanningSource {
+  auto
+  manual
+}
+
+enum FocusSessionStatus {
+  active
+  completed
+  cancelled
+}
+
+enum SyncMode {
+  polling
+  webhook
+}
+
+enum Provider {
+  google
+  ical
+  local
+}
+
+model User {
+  id               String               @id @default(uuid())
+  email            String               @unique
+  display_name     String
+  settings         Json?
+  onboarding_state String?
+  created_at       DateTime             @default(now())
+  updated_at       DateTime             @updatedAt
+
+  tasks               Task[]
+  task_imports        TaskImport[]
+  subtasks            Subtask[]
+  time_blocks         TimeBlock[]
+  channels            Channel[]
+  planning_sessions   PlanningSession[]
+  objectives          Objective[]
+  focus_sessions      FocusSession[]
+  calendar_integrations CalendarIntegration[]
+  audit_logs          AuditLog[]
+}
+
+model Task {
+  id                String         @id @default(uuid())
+  user              User           @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id           String
+  title             String
+  rich_notes        String?        @db.Text
+  status            TaskStatus     @default(todo)
+  priority_score    Float? 
+  priority_level    Int            @default(3)
+  due_at            DateTime?
+  planned_minutes   Int?
+  estimated_minutes Int?
+  actual_minutes    Int?
+  channel           Channel?       @relation(fields: [channel_id], references: [id])
+  channel_id        String?
+  planned_sessions  String[]      @default([])
+  recurrence_rule   String?
+  rollover_state    Json?
+  labels            String[]      @default([])
+  created_at        DateTime       @default(now())
+  updated_at        DateTime       @updatedAt
+
+  subtasks          Subtask[]
+  time_blocks       TimeBlock[]
+  focus_sessions    FocusSession[]
+  task_imports      TaskImport[]
+
+  @@index([user_id, status])
+  @@index([user_id, priority_score(sort: Desc)])
+  @@index([user_id, due_at])
+  @@index([user_id, channel_id])
+  @@index([labels], type: Gin)
+}
+
+model Subtask {
+  id         String     @id @default(uuid())
+  task       Task       @relation(fields: [task_id], references: [id], onDelete: Cascade)
+  task_id    String
+  title      String
+  status     TaskStatus @default(todo)
+  order      Int
+  created_at DateTime   @default(now())
+  updated_at DateTime   @updatedAt
+
+  @@index([task_id, order])
+}
+
+model TaskImport {
+  id         String          @id @default(uuid())
+  user       User            @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id    String
+  source     String
+  source_ref String
+  payload    Json
+  task       Task?           @relation(fields: [task_id], references: [id])
+  task_id    String?
+  state      TaskImportState @default(proposed)
+  created_at DateTime        @default(now())
+}
+
+model TimeBlock {
+  id                 String          @id @default(uuid())
+  user               User            @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id            String
+  task               Task?           @relation(fields: [task_id], references: [id])
+  task_id            String?
+  start_at           DateTime
+  end_at             DateTime
+  status             TimeBlockStatus @default(tentative)
+  location           String?
+  notes              String?         @db.Text
+  calendar_event_id  String?
+  provider           Provider
+  recurrence_rule    String?
+  created_at         DateTime        @default(now())
+  updated_at         DateTime        @updatedAt
+
+  @@index([user_id, start_at, end_at])
+}
+
+model Channel {
+  id                 String            @id @default(uuid())
+  user               User              @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id            String
+  name               String
+  visibility         ChannelVisibility @default(private)
+  target_calendar_id String?
+  color              String?
+  created_at         DateTime          @default(now())
+  updated_at         DateTime          @updatedAt
+
+  tasks              Task[]
+}
+
+model PlanningSession {
+  id            String              @id @default(uuid())
+  user          User                @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id       String
+  type          PlanningSessionType
+  started_at    DateTime
+  completed_at  DateTime?
+  context       PlanningContext
+  source        PlanningSource
+  notes         String?             @db.Text
+
+  @@index([user_id, started_at(sort: Desc)])
+}
+
+model Objective {
+  id            String     @id @default(uuid())
+  user          User       @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id       String
+  type          String
+  title         String
+  description   String?    @db.Text
+  target_week   DateTime?
+  status        String?
+  created_at    DateTime   @default(now())
+  updated_at    DateTime   @updatedAt
+}
+
+model FocusSession {
+  id              String             @id @default(uuid())
+  user            User               @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id         String
+  task            Task               @relation(fields: [task_id], references: [id], onDelete: Cascade)
+  task_id         String
+  start_at        DateTime
+  end_at          DateTime
+  planned_minutes Int
+  actual_minutes  Int?
+  status          FocusSessionStatus @default(active)
+  interruptions   Json?
+  created_at      DateTime           @default(now())
+
+  @@index([user_id, start_at(sort: Desc)])
+}
+
+model CalendarIntegration {
+  id             String    @id @default(uuid())
+  user           User      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id        String
+  provider       Provider
+  access_token   String
+  refresh_token  String?
+  expires_at     DateTime?
+  sync_state     Json?
+  sync_mode      SyncMode  @default(polling)
+  calendar_id    String?
+
+  @@index([user_id, provider])
+}
+
+model AuditLog {
+  id          String   @id @default(uuid())
+  user        User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user_id     String
+  action      String
+  entity_type String
+  entity_id   String
+  metadata    Json?
+  created_at  DateTime @default(now())
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,137 @@
+import { PrismaClient, TaskStatus, TimeBlockStatus, FocusSessionStatus, PlanningSessionType, PlanningContext, PlanningSource, ChannelVisibility, Provider, SyncMode } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const user = await prisma.user.upsert({
+    where: { email: 'dev@example.com' },
+    update: {},
+    create: {
+      email: 'dev@example.com',
+      display_name: 'Dev User',
+      onboarding_state: 'completed',
+      settings: {
+        timeZone: 'UTC',
+        workingHours: { start: '09:00', end: '17:00' },
+      },
+    },
+  });
+
+  const channel = await prisma.channel.upsert({
+    where: { id: 'default-channel' },
+    update: {},
+    create: {
+      id: 'default-channel',
+      name: 'Work',
+      user_id: user.id,
+      visibility: ChannelVisibility.private,
+      color: '#4F46E5',
+    },
+  });
+
+  const planningSession = await prisma.planningSession.create({
+    data: {
+      user_id: user.id,
+      type: PlanningSessionType.morning,
+      started_at: new Date(),
+      completed_at: new Date(),
+      context: PlanningContext.work,
+      source: PlanningSource.manual,
+      notes: 'Kick off the day with priority planning.',
+    },
+  });
+
+  const task = await prisma.task.create({
+    data: {
+      user_id: user.id,
+      title: 'Plan sprint backlog',
+      status: TaskStatus.in_progress,
+      priority_score: 4.5,
+      priority_level: 4,
+      due_at: new Date(Date.now() + 72 * 60 * 60 * 1000),
+      planned_minutes: 90,
+      estimated_minutes: 120,
+      channel_id: channel.id,
+      planned_sessions: [planningSession.id],
+      labels: ['planning', 'sprint'],
+      rollover_state: { carried_from_date: null, rolled_minutes: 0 },
+      rich_notes: 'Align with the team on priorities and dependencies.',
+      time_blocks: {
+        create: [
+          {
+            user_id: user.id,
+            start_at: new Date(Date.now() + 2 * 60 * 60 * 1000),
+            end_at: new Date(Date.now() + 3 * 60 * 60 * 1000),
+            status: TimeBlockStatus.confirmed,
+            provider: Provider.local,
+            notes: 'Deep work block to organize backlog items.',
+          },
+        ],
+      },
+      subtasks: {
+        create: [
+          { title: 'Review carryover tasks', status: TaskStatus.todo, order: 1 },
+          { title: 'Prioritize new requests', status: TaskStatus.todo, order: 2 },
+        ],
+      },
+    },
+  });
+
+  await prisma.focusSession.create({
+    data: {
+      user_id: user.id,
+      task_id: task.id,
+      start_at: new Date(Date.now() + 2.5 * 60 * 60 * 1000),
+      end_at: new Date(Date.now() + 3.5 * 60 * 60 * 1000),
+      planned_minutes: 60,
+      actual_minutes: 55,
+      status: FocusSessionStatus.completed,
+      interruptions: { pings: 2 },
+    },
+  });
+
+  await prisma.objective.create({
+    data: {
+      user_id: user.id,
+      type: 'weekly',
+      title: 'Ship next sprint plan',
+      description: 'Finalize the plan and share with stakeholders.',
+      target_week: new Date(),
+      status: 'in-progress',
+    },
+  });
+
+  await prisma.calendarIntegration.upsert({
+    where: { id: 'dev-google-calendar' },
+    update: {},
+    create: {
+      id: 'dev-google-calendar',
+      user_id: user.id,
+      provider: Provider.google,
+      access_token: 'dummy-access-token',
+      refresh_token: 'dummy-refresh-token',
+      sync_state: { last_sync_at: new Date().toISOString(), cursor: 'initial' },
+      sync_mode: SyncMode.polling,
+      calendar_id: 'primary',
+    },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      user_id: user.id,
+      action: 'seed',
+      entity_type: 'User',
+      entity_id: user.id,
+      metadata: { reason: 'Initial development data' },
+    },
+  });
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add Prisma data model, enums, and indexes for scheduling entities
- include initial migration SQL and migrate lock file
- create seed script and document database commands in backend README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae08bc47c83318cb3b05a706c14ea)