### PR TITLE
Add Express routing, validation, and task CRUD endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/backend/src/__tests__/tasks.integration.test.ts
+++ b/backend/src/__tests__/tasks.integration.test.ts
@@ -1,0 +1,73 @@
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import type { Express } from 'express';
+import request from 'supertest';
+import type { PrismaClient } from '@prisma/client';
+
+let app: Express;
+let prisma: PrismaClient;
+let schema: string;
+
+beforeAll(async () => {
+  const baseDatabaseUrl =
+    process.env.TEST_DATABASE_URL || 'postgresql://app:password@localhost:5432/app_db';
+  schema = `test_${randomUUID().replace(/-/g, '')}`;
+  const databaseUrl = `${baseDatabaseUrl}?schema=${schema}`;
+  process.env.DATABASE_URL = databaseUrl;
+
+  execSync('npx prisma migrate deploy', {
+    env: { ...process.env, DATABASE_URL: databaseUrl },
+    stdio: 'inherit',
+  });
+
+  const appModule = await import('../app');
+  ({ prisma } = await import('../lib/prisma'));
+  app = appModule.default;
+});
+
+afterAll(async () => {
+  await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  await prisma.$disconnect();
+});
+
+describe('tasks integration', () => {
+  it('creates, lists, updates, and deletes a task', async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: 'integration@example.com',
+        display_name: 'Integration User',
+      },
+    });
+
+    const createResponse = await request(app).post('/tasks').send({
+      userId: user.id,
+      title: 'Write integration tests',
+      priorityLevel: 4,
+    });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.title).toBe('Write integration tests');
+
+    const listResponse = await request(app).get('/tasks').query({ userId: user.id });
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body).toHaveLength(1);
+
+    const taskId = createResponse.body.id;
+    const updateResponse = await request(app)
+      .patch(`/tasks/${taskId}`)
+      .send({ status: 'in_progress', priorityScore: 0.9 });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.status).toBe('in_progress');
+    expect(updateResponse.body.priorityScore).toBe(0.9);
+
+    const priorityResponse = await request(app)
+      .post(`/tasks/${taskId}/priority`)
+      .send({ priorityLevel: 2 });
+    expect(priorityResponse.status).toBe(200);
+    expect(priorityResponse.body.priorityLevel).toBe(2);
+
+    const deleteResponse = await request(app).delete(`/tasks/${taskId}`);
+    expect(deleteResponse.status).toBe(204);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import { errorHandler } from './middleware/error-handler';
+import { requestLogger } from './middleware/request-logger';
+import router from './routes';
+
+const app = express();
+app.use(express.json());
+app.use(requestLogger);
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.use(router);
+
+app.use(errorHandler);
+
+export default app;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,11 +1,6 @@
-import express from 'express';
+import app from './app';
 
-const app = express();
 const port = process.env.PORT || 3001;
-
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
-});
 
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => {

--- a/backend/src/lib/http-error.ts
+++ b/backend/src/lib/http-error.ts
@@ -1,0 +1,10 @@
+export class HttpError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor(status: number, message: string, details?: unknown) {
+    super(message);
+    this.status = status;
+    this.details = details;
+  }
+}

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from 'node:crypto';
+import type { Request, Response } from 'express';
+
+type LogLevel = 'info' | 'error';
+
+interface LogEntry {
+  level: LogLevel;
+  message: string;
+  requestId?: string;
+  [key: string]: unknown;
+}
+
+export const log = (entry: LogEntry) => {
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      ...entry,
+    }),
+  );
+};
+
+export const getRequestId = (req: Request) => {
+  const headerId = req.header('x-request-id');
+  return headerId ?? randomUUID();
+};
+
+export const logRequest = (req: Request, res: Response) => {
+  const start = process.hrtime.bigint();
+  const requestId = getRequestId(req);
+
+  res.setHeader('x-request-id', requestId);
+
+  res.on('finish', () => {
+    const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+    log({
+      level: 'info',
+      message: 'request_completed',
+      requestId,
+      method: req.method,
+      path: req.originalUrl,
+      statusCode: res.statusCode,
+      durationMs: Number(durationMs.toFixed(2)),
+    });
+  });
+};
+
+export const logError = (entry: LogEntry) => {
+  log({ level: 'error', ...entry });
+};

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/backend/src/middleware/error-handler.ts
+++ b/backend/src/middleware/error-handler.ts
@@ -1,0 +1,29 @@
+import type { NextFunction, Request, Response } from 'express';
+import { HttpError } from '../lib/http-error';
+import { logError } from '../lib/logger';
+
+export const errorHandler = (
+  err: Error,
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+) => {
+  const status = err instanceof HttpError ? err.status : 500;
+  const requestId = res.getHeader('x-request-id') as string | undefined;
+
+  logError({
+    message: err.message,
+    level: 'error',
+    requestId,
+    stack: err.stack,
+    details: err instanceof HttpError ? err.details : undefined,
+  });
+
+  res.status(status).json({
+    error: {
+      message: err.message,
+      details: err instanceof HttpError ? err.details : undefined,
+      requestId,
+    },
+  });
+};

--- a/backend/src/middleware/request-logger.ts
+++ b/backend/src/middleware/request-logger.ts
@@ -1,0 +1,7 @@
+import type { Request, Response, NextFunction } from 'express';
+import { logRequest } from '../lib/logger';
+
+export const requestLogger = (req: Request, res: Response, next: NextFunction) => {
+  logRequest(req, res);
+  next();
+};

--- a/backend/src/middleware/validate-request.ts
+++ b/backend/src/middleware/validate-request.ts
@@ -1,0 +1,32 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { AnyZodObject, ZodError } from 'zod';
+import { HttpError } from '../lib/http-error';
+
+export interface ValidationSchema {
+  body?: AnyZodObject;
+  params?: AnyZodObject;
+  query?: AnyZodObject;
+}
+
+export const validateRequest = (schema: ValidationSchema) =>
+  (req: Request, _res: Response, next: NextFunction) => {
+    try {
+      if (schema.body) {
+        req.body = schema.body.parse(req.body);
+      }
+      if (schema.params) {
+        req.params = schema.params.parse(req.params);
+      }
+      if (schema.query) {
+        req.query = schema.query.parse(req.query);
+      }
+      next();
+    } catch (error) {
+      const zodError = error as ZodError;
+      const details = zodError.issues?.map((issue) => ({
+        message: issue.message,
+        path: issue.path,
+      }));
+      next(new HttpError(400, 'Validation failed', details));
+    }
+  };

--- a/backend/src/modules/focus-sessions/focus-sessions.router.ts
+++ b/backend/src/modules/focus-sessions/focus-sessions.router.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { validateRequest } from '../../middleware/validate-request';
+
+const focusSessionRouter = Router();
+
+const createFocusSessionSchema = {
+  body: z.object({
+    userId: z.string().uuid(),
+    taskId: z.string().uuid(),
+    plannedMinutes: z.number().int().positive(),
+  }),
+};
+
+focusSessionRouter.post('/', validateRequest(createFocusSessionSchema), (req, res) => {
+  const { userId, taskId, plannedMinutes } = req.body;
+  res.status(201).json({
+    userId,
+    taskId,
+    plannedMinutes,
+    status: 'active',
+  });
+});
+
+focusSessionRouter.get('/', (_req, res) => {
+  res.json({ message: 'Focus sessions not implemented yet' });
+});
+
+export default focusSessionRouter;

--- a/backend/src/modules/planning-sessions/planning-sessions.router.ts
+++ b/backend/src/modules/planning-sessions/planning-sessions.router.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { validateRequest } from '../../middleware/validate-request';
+
+const planningSessionRouter = Router();
+
+const createPlanningSessionSchema = {
+  body: z.object({
+    userId: z.string().uuid(),
+    type: z.enum(['morning', 'evening', 'weekly', 'custom']),
+    context: z.enum(['work', 'personal']),
+  }),
+};
+
+planningSessionRouter.post(
+  '/',
+  validateRequest(createPlanningSessionSchema),
+  (req, res) => {
+    const { userId, type, context } = req.body;
+    res.status(201).json({ userId, type, context, status: 'pending' });
+  },
+);
+
+planningSessionRouter.get('/', (_req, res) => {
+  res.json({ message: 'Planning sessions not implemented yet' });
+});
+
+export default planningSessionRouter;

--- a/backend/src/modules/sync/providers/google.router.ts
+++ b/backend/src/modules/sync/providers/google.router.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { validateRequest } from '../../../middleware/validate-request';
+
+const syncProviderRouter = Router();
+
+const oauthStartSchema = {
+  body: z.object({
+    userId: z.string().uuid(),
+    scopes: z.array(z.string()).nonempty(),
+  }),
+};
+
+syncProviderRouter.post('/connect', validateRequest(oauthStartSchema), (req, res) => {
+  const { userId, scopes } = req.body;
+  res.status(202).json({ provider: 'google', userId, scopes, status: 'pending' });
+});
+
+syncProviderRouter.post('/disconnect', (_req, res) => {
+  res.json({ provider: 'google', status: 'disconnected' });
+});
+
+syncProviderRouter.post('/webhook', (_req, res) => {
+  res.json({ provider: 'google', message: 'Webhook received' });
+});
+
+export default syncProviderRouter;

--- a/backend/src/modules/tasks/task.mapper.ts
+++ b/backend/src/modules/tasks/task.mapper.ts
@@ -1,0 +1,25 @@
+import type { Task } from '@prisma/client';
+
+export interface TaskResponse {
+  id: string;
+  userId: string;
+  title: string;
+  status: string;
+  priorityLevel: number;
+  priorityScore: number | null;
+  dueAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const toTaskResponse = (task: Task): TaskResponse => ({
+  id: task.id,
+  userId: task.user_id,
+  title: task.title,
+  status: task.status,
+  priorityLevel: task.priority_level,
+  priorityScore: task.priority_score,
+  dueAt: task.due_at ? task.due_at.toISOString() : null,
+  createdAt: task.created_at.toISOString(),
+  updatedAt: task.updated_at.toISOString(),
+});

--- a/backend/src/modules/tasks/task.schemas.ts
+++ b/backend/src/modules/tasks/task.schemas.ts
@@ -1,0 +1,61 @@
+import { TaskStatus } from '@prisma/client';
+import { z } from 'zod';
+
+const isoDate = z.string().datetime({ offset: true }).optional();
+
+export const createTaskSchema = {
+  body: z.object({
+    userId: z.string().uuid(),
+    title: z.string().min(1),
+    status: z.nativeEnum(TaskStatus).optional(),
+    priorityLevel: z.number().int().min(1).max(5).optional(),
+    priorityScore: z.number().nullable().optional(),
+    dueAt: isoDate,
+    notes: z.string().optional(),
+  }),
+};
+
+export const updateTaskSchema = {
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+  body: z
+    .object({
+      title: z.string().min(1).optional(),
+      status: z.nativeEnum(TaskStatus).optional(),
+      priorityLevel: z.number().int().min(1).max(5).optional(),
+      priorityScore: z.number().nullable().optional(),
+      dueAt: isoDate,
+      notes: z.string().optional(),
+    })
+    .refine((data) => Object.keys(data).length > 0, {
+      message: 'At least one field must be provided for update',
+    }),
+};
+
+export const priorityUpdateSchema = {
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+  body: z
+    .object({
+      priorityLevel: z.number().int().min(1).max(5).optional(),
+      priorityScore: z.number().nullable().optional(),
+    })
+    .refine((data) => Object.keys(data).length > 0, {
+      message: 'priorityLevel or priorityScore is required',
+    }),
+};
+
+export const taskIdSchema = {
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+};
+
+export const taskListSchema = {
+  query: z.object({
+    userId: z.string().uuid(),
+    status: z.nativeEnum(TaskStatus).optional(),
+  }),
+};

--- a/backend/src/modules/tasks/tasks.router.ts
+++ b/backend/src/modules/tasks/tasks.router.ts
@@ -1,0 +1,140 @@
+import { Prisma } from '@prisma/client';
+import { Router } from 'express';
+import { HttpError } from '../../lib/http-error';
+import { prisma } from '../../lib/prisma';
+import { validateRequest } from '../../middleware/validate-request';
+import { toTaskResponse } from './task.mapper';
+import {
+  createTaskSchema,
+  priorityUpdateSchema,
+  taskIdSchema,
+  taskListSchema,
+  updateTaskSchema,
+} from './task.schemas';
+
+const tasksRouter = Router();
+
+const handleNotFound = (id: string) => new HttpError(404, `Task ${id} not found`);
+
+const parseDate = (value?: string | null) => (value ? new Date(value) : null);
+
+const handlePrismaError = (error: unknown, id: string) => {
+  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+    throw handleNotFound(id);
+  }
+  throw error;
+};
+
+tasksRouter.post('/', validateRequest(createTaskSchema), async (req, res, next) => {
+  const { userId, title, status, priorityLevel, priorityScore, dueAt, notes } = req.body;
+
+  try {
+    const task = await prisma.task.create({
+      data: {
+        user_id: userId,
+        title,
+        status,
+        priority_level: priorityLevel ?? 3,
+        priority_score: priorityScore ?? null,
+        due_at: parseDate(dueAt),
+        rich_notes: notes,
+      },
+    });
+
+    res.status(201).json(toTaskResponse(task));
+  } catch (error) {
+    next(error);
+  }
+});
+
+tasksRouter.get('/', validateRequest(taskListSchema), async (req, res, next) => {
+  const { userId, status } = req.query as { userId: string; status?: string };
+
+  try {
+    const tasks = await prisma.task.findMany({
+      where: {
+        user_id: userId,
+        status,
+      },
+      orderBy: { created_at: 'desc' },
+    });
+
+    res.json(tasks.map(toTaskResponse));
+  } catch (error) {
+    next(error);
+  }
+});
+
+tasksRouter.get('/:id', validateRequest(taskIdSchema), async (req, res, next) => {
+  const { id } = req.params;
+
+  try {
+    const task = await prisma.task.findUnique({ where: { id } });
+    if (!task) {
+      throw handleNotFound(id);
+    }
+
+    res.json(toTaskResponse(task));
+  } catch (error) {
+    next(error);
+  }
+});
+
+tasksRouter.patch('/:id', validateRequest(updateTaskSchema), async (req, res, next) => {
+  const { id } = req.params;
+  const { title, status, priorityLevel, priorityScore, dueAt, notes } = req.body;
+
+  try {
+    const task = await prisma.task.update({
+      where: { id },
+      data: {
+        title,
+        status,
+        priority_level: priorityLevel,
+        priority_score: priorityScore,
+        due_at: parseDate(dueAt),
+        rich_notes: notes,
+      },
+    });
+
+    res.json(toTaskResponse(task));
+  } catch (error) {
+    next(handlePrismaError(error, id));
+  }
+});
+
+tasksRouter.delete('/:id', validateRequest(taskIdSchema), async (req, res, next) => {
+  const { id } = req.params;
+
+  try {
+    await prisma.task.delete({ where: { id } });
+    res.status(204).send();
+  } catch (error) {
+    next(handlePrismaError(error, id));
+  }
+});
+
+tasksRouter.post(
+  '/:id/priority',
+  validateRequest(priorityUpdateSchema),
+  async (req, res, next) => {
+    const { id } = req.params;
+    const { priorityLevel, priorityScore } = req.body;
+
+    try {
+      const task = await prisma.task.update({
+        where: { id },
+        data: {
+          priority_level: priorityLevel,
+          priority_score: priorityScore ?? null,
+        },
+      });
+
+      res.json(toTaskResponse(task));
+    } catch (error) {
+      next(handlePrismaError(error, id));
+    }
+  },
+);
+
+export default tasksRouter;

--- a/backend/src/modules/timeblocks/timeblocks.router.ts
+++ b/backend/src/modules/timeblocks/timeblocks.router.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { validateRequest } from '../../middleware/validate-request';
+import { z } from 'zod';
+
+const timeblocksRouter = Router();
+
+const createTimeblockSchema = {
+  body: z.object({
+    userId: z.string().uuid(),
+    startAt: z.string().datetime(),
+    endAt: z.string().datetime(),
+    taskId: z.string().uuid().optional(),
+  }),
+};
+
+timeblocksRouter.post('/', validateRequest(createTimeblockSchema), (req, res) => {
+  const { userId, startAt, endAt, taskId } = req.body;
+  res.status(201).json({
+    userId,
+    startAt,
+    endAt,
+    taskId: taskId ?? null,
+    status: 'tentative',
+  });
+});
+
+timeblocksRouter.get('/', (_req, res) => {
+  res.json({ message: 'Timeblock listing not implemented yet' });
+});
+
+export default timeblocksRouter;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import focusSessionRouter from '../modules/focus-sessions/focus-sessions.router';
+import planningSessionRouter from '../modules/planning-sessions/planning-sessions.router';
+import syncProviderRouter from '../modules/sync/providers/google.router';
+import tasksRouter from '../modules/tasks/tasks.router';
+import timeblocksRouter from '../modules/timeblocks/timeblocks.router';
+
+const router = Router();
+
+router.use('/tasks', tasksRouter);
+router.use('/timeblocks', timeblocksRouter);
+router.use('/planning-sessions', planningSessionRouter);
+router.use('/focus-sessions', focusSessionRouter);
+router.use('/sync/providers/google', syncProviderRouter);
+
+export default router;


### PR DESCRIPTION
## Summary
- set up the Express app with modular routers plus structured logging, validation, and error handling
- implement Prisma-backed task CRUD and priority update endpoints with DTO mappers
- scaffold feature routers and add integration coverage that boots against an isolated test schema

## Testing
- Not run (npm install blocked by 403 errors against the npm registry)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae213119083318ed1922962b2b108)