### PR TITLE
Persist focus/planning sessions and add planner page

### DIFF
--- a/backend/src/modules/focus-sessions/focus-sessions.router.ts
+++ b/backend/src/modules/focus-sessions/focus-sessions.router.ts
@@ -1,17 +1,28 @@
-import { randomUUID } from 'crypto';
+import type { FocusSessionStatus } from '@prisma/client';
 import { Router } from 'express';
+import { prisma } from '../../lib/prisma';
 import { z } from '../../lib/zod';
 import { validateRequest } from '../../middleware/validate-request';
 
 const focusSessionRouter = Router();
 
 const createFocusSessionSchema = {
-  body: z.object({
-    userId: z.string().uuid(),
-    taskId: z.string().uuid(),
-    plannedMinutes: z.number().int().positive(),
-    goal: z.string().optional(),
-  }),
+  body: z
+    .object({
+      userId: z.string().uuid(),
+      taskId: z.string().uuid(),
+      plannedMinutes: z.number().int().positive(),
+      startAt: z.string().datetime().optional(),
+      endAt: z.string().datetime().optional(),
+      goal: z.string().optional(),
+    })
+    .refine(
+      ({ startAt, endAt }) => {
+        if (!startAt || !endAt) return true;
+        return new Date(endAt) > new Date(startAt);
+      },
+      { path: ['endAt'], message: 'endAt must be after startAt' }
+    ),
 };
 
 const completeFocusSessionSchema = {
@@ -23,55 +34,114 @@ const completeFocusSessionSchema = {
   }),
 };
 
+const listFocusSessionsSchema = {
+  query: z.object({
+    userId: z.string().uuid(),
+    status: z
+      .enum(['active', 'completed', 'cancelled'])
+      .optional() as z.ZodType<FocusSessionStatus | undefined>,
+  }),
+};
+
+const toResponse = (session: {
+  id: string;
+  user_id: string;
+  task_id: string;
+  start_at: Date;
+  end_at: Date;
+  planned_minutes: number;
+  actual_minutes: number | null;
+  status: FocusSessionStatus;
+  interruptions: unknown;
+  created_at: Date;
+}) => ({
+  id: session.id,
+  userId: session.user_id,
+  taskId: session.task_id,
+  startAt: session.start_at.toISOString(),
+  endAt: session.end_at.toISOString(),
+  plannedMinutes: session.planned_minutes,
+  actualMinutes: session.actual_minutes,
+  status: session.status,
+  interruptions: session.interruptions,
+  createdAt: session.created_at?.toISOString(),
+});
+
 focusSessionRouter.post(
   '/',
   validateRequest(createFocusSessionSchema),
-  (req, res) => {
-    const { userId, taskId, plannedMinutes, goal } = req.body;
-    res.status(201).json({
-      id: randomUUID(),
-      userId,
-      taskId,
-      plannedMinutes,
-      goal,
-      status: 'active',
-      startedAt: new Date().toISOString(),
-    });
+  async (req, res, next) => {
+    const { userId, taskId, plannedMinutes, startAt, endAt, goal } = req.body;
+
+    try {
+      const parsedStart = startAt ? new Date(startAt) : new Date();
+      const parsedEnd = endAt
+        ? new Date(endAt)
+        : new Date(parsedStart.getTime() + plannedMinutes * 60 * 1000);
+
+      const session = await prisma.focusSession.create({
+        data: {
+          user_id: userId,
+          task_id: taskId,
+          planned_minutes: plannedMinutes,
+          start_at: parsedStart,
+          end_at: parsedEnd,
+          interruptions: goal ? { goal } : undefined,
+        },
+      });
+
+      res.status(201).json(toResponse(session));
+    } catch (error) {
+      next(error);
+    }
   }
 );
 
 focusSessionRouter.patch(
   '/:id/complete',
   validateRequest(completeFocusSessionSchema),
-  (req, res) => {
+  async (req, res, next) => {
     const { id } = req.params;
     const { actualMinutes, summary, interruptions } = req.body;
-    res.json({
-      id,
-      status: 'completed',
-      actualMinutes,
-      interruptions,
-      completedAt: new Date().toISOString(),
-      summary,
-    });
+
+    try {
+      const session = await prisma.focusSession.update({
+        where: { id },
+        data: {
+          status: 'completed',
+          actual_minutes: actualMinutes,
+          end_at: new Date(),
+          interruptions: { summary, interruptions },
+        },
+      });
+
+      res.json(toResponse(session));
+    } catch (error) {
+      next(error);
+    }
   }
 );
 
-focusSessionRouter.get('/', (_req, res) => {
-  res.json({
-    sessions: [
-      {
-        id: 'fs-1',
-        userId: 'f1c3b317-1111-4b0c-9b44-2b2fd0d3f111',
-        taskId: 't-1',
-        plannedMinutes: 50,
-        actualMinutes: 45,
-        status: 'completed',
-        startedAt: new Date(Date.now() - 1000 * 60 * 70).toISOString(),
-        completedAt: new Date(Date.now() - 1000 * 60 * 20).toISOString(),
-      },
-    ],
-  });
-});
+focusSessionRouter.get(
+  '/',
+  validateRequest(listFocusSessionsSchema),
+  async (req, res, next) => {
+    const { userId, status } = req.query as {
+      userId: string;
+      status?: FocusSessionStatus;
+    };
+
+    try {
+      const sessions = await prisma.focusSession.findMany({
+        where: { user_id: userId, status },
+        orderBy: { start_at: 'desc' },
+      });
+
+      res.json(sessions.map(toResponse));
+    } catch (error) {
+      next(error);
+    }
+  }
+);
 
 export default focusSessionRouter;

--- a/backend/src/modules/sync/providers/google.router.ts
+++ b/backend/src/modules/sync/providers/google.router.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { prisma } from '../../../lib/prisma';
 import { z } from '../../../lib/zod';
 import { validateRequest } from '../../../middleware/validate-request';
 
@@ -8,23 +9,71 @@ const oauthStartSchema = {
   body: z.object({
     userId: z.string().uuid(),
     scopes: z.array(z.string()).nonempty(),
+    accessToken: z.string(),
+    refreshToken: z.string().optional(),
+    expiresAt: z.string().datetime().optional(),
   }),
 };
 
 syncProviderRouter.post(
   '/connect',
   validateRequest(oauthStartSchema),
-  (req, res) => {
-    const { userId, scopes } = req.body;
-    res
-      .status(202)
-      .json({ provider: 'google', userId, scopes, status: 'pending' });
+  async (req, res, next) => {
+    const { userId, scopes, accessToken, refreshToken, expiresAt } = req.body;
+
+    try {
+      const integration = await prisma.calendarIntegration.upsert({
+        where: {
+          user_id_provider: { user_id: userId, provider: 'google' },
+        },
+        update: {
+          access_token: accessToken,
+          refresh_token: refreshToken,
+          expires_at: expiresAt ? new Date(expiresAt) : null,
+          sync_state: { scopes },
+        },
+        create: {
+          user_id: userId,
+          provider: 'google',
+          access_token: accessToken,
+          refresh_token: refreshToken,
+          expires_at: expiresAt ? new Date(expiresAt) : null,
+          sync_state: { scopes },
+        },
+      });
+
+      res
+        .status(202)
+        .json({
+          provider: 'google',
+          userId,
+          scopes,
+          status: 'connected',
+          integrationId: integration.id,
+        });
+    } catch (error) {
+      next(error);
+    }
   }
 );
 
-syncProviderRouter.post('/disconnect', (_req, res) => {
-  res.json({ provider: 'google', status: 'disconnected' });
-});
+syncProviderRouter.post(
+  '/disconnect',
+  validateRequest({ body: z.object({ userId: z.string().uuid() }) }),
+  async (req, res, next) => {
+    const { userId } = req.body;
+
+    try {
+      await prisma.calendarIntegration.deleteMany({
+        where: { user_id: userId, provider: 'google' },
+      });
+
+      res.json({ provider: 'google', status: 'disconnected' });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
 
 syncProviderRouter.post('/webhook', (_req, res) => {
   res.json({ provider: 'google', message: 'Webhook received' });

--- a/frontend/src/pages/planner.tsx
+++ b/frontend/src/pages/planner.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import styles from './index.module.css';
+
+type Task = {
+  id: string;
+  title: string;
+  status: string;
+};
+
+type Timeblock = {
+  id: string;
+  taskId?: string | null;
+  startAt: string;
+  endAt: string;
+  status: string;
+};
+
+const fallbackTasks: Task[] = [
+  { id: 't-1', title: 'Finish onboarding doc', status: 'todo' },
+  { id: 't-2', title: 'Plan weekly priorities', status: 'in_progress' },
+];
+
+const fallbackBlocks: Timeblock[] = [
+  {
+    id: 'tb-1',
+    taskId: 't-1',
+    startAt: new Date().toISOString(),
+    endAt: new Date(Date.now() + 45 * 60 * 1000).toISOString(),
+    status: 'tentative',
+  },
+];
+
+export default function PlannerPage() {
+  const [tasks, setTasks] = useState<Task[]>(fallbackTasks);
+  const [timeblocks, setTimeblocks] = useState<Timeblock[]>(fallbackBlocks);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [taskRes, blockRes] = await Promise.all([
+          fetch('/api/tasks?userId=demo'),
+          fetch('/api/timeblocks?userId=demo'),
+        ]);
+
+        if (taskRes.ok) {
+          const data = await taskRes.json();
+          setTasks(Array.isArray(data) ? data : data.tasks ?? fallbackTasks);
+        }
+
+        if (blockRes.ok) {
+          const data = await blockRes.json();
+          setTimeblocks(Array.isArray(data) ? data : data ?? fallbackBlocks);
+        }
+      } catch (error) {
+        console.warn('Falling back to sample planner data', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <main className={styles.main}>
+      <div className={styles.grid}>
+        <section>
+          <h1>Tasks</h1>
+          <ul>
+            {tasks.map((task) => (
+              <li key={task.id}>
+                <strong>{task.title}</strong>
+                <div className={styles.description}>Status: {task.status}</div>
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h1>Timeblocks</h1>
+          <ul>
+            {timeblocks.map((block) => (
+              <li key={block.id}>
+                <div>{new Date(block.startAt).toLocaleTimeString()} → {new Date(block.endAt).toLocaleTimeString()}</div>
+                <div className={styles.description}>Status: {block.status}</div>
+                {block.taskId && <div className={styles.description}>Task: {block.taskId}</div>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- persist focus sessions with Prisma and add filtering plus completion handling
- store planning sessions and Google calendar connections in the database instead of returning static payloads
- add a lightweight planner page that surfaces tasks and timeblocks with a simple grid layout

## Testing
- npm --prefix backend run type-check *(fails: existing TypeScript configuration errors unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b13ab953483318d6a4d2a62e2ad66)