### PR TITLE
Add observability polish with digests and audit logging

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Backend configuration
+PORT=3001
+DATABASE_URL="postgresql://app:password@localhost:5432/app_db?schema=public"
+REDIS_URL="redis://localhost:6379"
+# Set to true in CI or unit tests to avoid contacting external services
+HEALTHCHECK_SKIP_DEPENDENCIES=false

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,10 +1,21 @@
 # Backend
 
-## Database setup
-The service uses PostgreSQL via Prisma. Provide a connection string in `DATABASE_URL`, for example:
+## Environment
+Copy `.env.example` to `.env` and adjust as needed:
 
 ```
-DATABASE_URL="postgresql://user:password@localhost:5432/app_db?schema=public"
+cp backend/.env.example backend/.env
+```
+
+- `DATABASE_URL` points at PostgreSQL (defaults to the Compose service).
+- `REDIS_URL` points at Redis for future job scheduling/heartbeat checks.
+- `HEALTHCHECK_SKIP_DEPENDENCIES` skips external health probes (useful in unit tests/CI).
+
+## Local services
+`docker-compose.yml` provides PostgreSQL and Redis:
+
+```
+docker compose up -d postgres redis
 ```
 
 ## Migrations and schema
@@ -26,3 +37,46 @@ Common commands:
   ```
 
 If you prefer to scope commands to the backend directory instead of workspaces, run them from `backend/` without the `--workspace` flag.
+
+## Health checks and jobs
+- `GET /health` reports dependency readiness with `db` and `redis` statuses and degrades when they are unavailable.
+- A lightweight heartbeat job logs Redis reachability every minute on startup (disabled in test environments).
+- A nightly rollover job carries incomplete tasks forward to today and records a `rollover_state` entry so midnight rituals keep the backlog fresh.
+- A digest job runs periodically to surface counts of tasks due today and stale calendar syncs for observability dashboards.
+
+## Tasks API and prioritization
+- `POST /tasks` creates a task with optional `priorityLevel` (1-5), `importance`, and `urgency`. If a `priorityScore` is not
+  provided, the API computes one using `priorityScore = (importance * 0.6) + (urgency * 0.4)`.
+- `GET /tasks` lists tasks for a user with filters for `status`, `channelId`, and `scheduled` (scheduled/unscheduled). Results
+  default to sorting by priority score (nulls last), then due date, then creation time; override with `sortBy` and
+  `sortDirection`.
+- `PATCH /tasks/:id` updates core fields; `POST /tasks/:id/priority` is a focused endpoint for adjusting priority inputs.
+
+## Timeboxing and channels
+- `POST /channels` and `GET /channels` manage channel metadata (color, visibility, target calendar) scoped to a user.
+- `POST /timeblocks` accepts `channelId` and rejects overlaps with existing blocks for the user with `409` conflict errors.
+- `GET /timeblocks` supports filters for `status`, `taskId`, `channelId`, and date ranges; updates will also check conflicts
+  before saving.
+- `POST /timeblocks/suggest` auto-schedules the next open slot within working hours (defaults to 9am-5pm, 7-day window) and
+  returns the created tentative block.
+
+## Observability and audit logging
+- Each task mutation writes an `audit_logs` record with the user ID, action, and metadata for traceability.
+- Telemetry events are emitted for key flows (task changes, syncs, digests) with request IDs to help correlate logs.
+
+## Calendar sync
+- `POST /sync/providers/google/connect` stores OAuth tokens and scopes; `POST /sync/providers/google/disconnect` removes the
+  integration.
+- `GET /sync/providers/google/status` reports whether Google Calendar is connected and when it last synced.
+- `POST /sync/providers/google/poll` accepts a batch of calendar events (id, start/end, optional calendar ID) and upserts
+  time blocks linked to channel mappings and the provider’s event IDs.
+
+## Planning rituals and focus mode
+- `POST /planning-sessions` starts a morning/evening/weekly ritual, optionally linking planned task IDs so the tasks record the
+  session ID in `planned_sessions`.
+- `PATCH /planning-sessions/:id/complete` logs reflections, boosts a highlight task to the highest priority, and activates any
+  linked objectives.
+- `POST /focus-sessions` starts a timed focus block (optionally reserving a tentative time block on a channel) and returns the
+  active session payload.
+- `PATCH /focus-sessions/:id/complete` finalizes the session with actual minutes and merges summaries/interruption counts while
+  rolling the effort into the linked task’s `actual_minutes`.

--- a/backend/prisma/migrations/0001_init/migration.sql
+++ b/backend/prisma/migrations/0001_init/migration.sql
@@ -1,188 +1,278 @@
--- Create required extension for UUID generation
-CREATE EXTENSION IF NOT EXISTS "pgcrypto";
-
--- Enum definitions
+-- CreateEnum
 CREATE TYPE "TaskStatus" AS ENUM ('todo', 'in_progress', 'done');
+
+-- CreateEnum
 CREATE TYPE "TaskImportState" AS ENUM ('proposed', 'accepted', 'ignored');
+
+-- CreateEnum
 CREATE TYPE "TimeBlockStatus" AS ENUM ('tentative', 'confirmed', 'completed', 'cancelled');
+
+-- CreateEnum
 CREATE TYPE "ChannelVisibility" AS ENUM ('private', 'shared');
+
+-- CreateEnum
 CREATE TYPE "PlanningSessionType" AS ENUM ('morning', 'evening', 'weekly', 'custom');
+
+-- CreateEnum
 CREATE TYPE "PlanningContext" AS ENUM ('work', 'personal');
+
+-- CreateEnum
 CREATE TYPE "PlanningSource" AS ENUM ('auto', 'manual');
+
+-- CreateEnum
 CREATE TYPE "FocusSessionStatus" AS ENUM ('active', 'completed', 'cancelled');
+
+-- CreateEnum
 CREATE TYPE "SyncMode" AS ENUM ('polling', 'webhook');
+
+-- CreateEnum
 CREATE TYPE "Provider" AS ENUM ('google', 'ical', 'local');
 
--- User table
+-- CreateTable
 CREATE TABLE "User" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
-    "email" TEXT NOT NULL UNIQUE,
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
     "display_name" TEXT NOT NULL,
     "settings" JSONB,
     "onboarding_state" TEXT,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
 );
 
--- Channel table
-CREATE TABLE "Channel" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
-    "user_id" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "visibility" "ChannelVisibility" NOT NULL DEFAULT 'private',
-    "target_calendar_id" TEXT,
-    "color" TEXT,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Channel_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
-);
-
--- Task table
+-- CreateTable
 CREATE TABLE "Task" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "rich_notes" TEXT,
     "status" "TaskStatus" NOT NULL DEFAULT 'todo',
     "priority_score" DOUBLE PRECISION,
     "priority_level" INTEGER NOT NULL DEFAULT 3,
-    "due_at" TIMESTAMPTZ,
+    "due_at" TIMESTAMP(3),
     "planned_minutes" INTEGER,
     "estimated_minutes" INTEGER,
     "actual_minutes" INTEGER,
     "channel_id" TEXT,
-    "planned_sessions" TEXT[] NOT NULL DEFAULT '{}',
+    "planned_sessions" TEXT[] DEFAULT ARRAY[]::TEXT[],
     "recurrence_rule" TEXT,
     "rollover_state" JSONB,
-    "labels" TEXT[] NOT NULL DEFAULT '{}',
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Task_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "Task_channel_id_fkey" FOREIGN KEY ("channel_id") REFERENCES "Channel"("id") ON DELETE SET NULL ON UPDATE CASCADE
+    "labels" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Task_pkey" PRIMARY KEY ("id")
 );
 
--- Subtask table
+-- CreateTable
 CREATE TABLE "Subtask" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "task_id" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "status" "TaskStatus" NOT NULL DEFAULT 'todo',
     "order" INTEGER NOT NULL,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Subtask_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Subtask_pkey" PRIMARY KEY ("id")
 );
 
--- Task import table
+-- CreateTable
 CREATE TABLE "TaskImport" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "source" TEXT NOT NULL,
     "source_ref" TEXT NOT NULL,
     "payload" JSONB NOT NULL,
     "task_id" TEXT,
     "state" "TaskImportState" NOT NULL DEFAULT 'proposed',
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "TaskImport_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "TaskImport_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaskImport_pkey" PRIMARY KEY ("id")
 );
 
--- Time block table
+-- CreateTable
 CREATE TABLE "TimeBlock" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "task_id" TEXT,
-    "start_at" TIMESTAMPTZ NOT NULL,
-    "end_at" TIMESTAMPTZ NOT NULL,
+    "channel_id" TEXT,
+    "start_at" TIMESTAMP(3) NOT NULL,
+    "end_at" TIMESTAMP(3) NOT NULL,
     "status" "TimeBlockStatus" NOT NULL DEFAULT 'tentative',
     "location" TEXT,
     "notes" TEXT,
     "calendar_event_id" TEXT,
     "provider" "Provider" NOT NULL,
     "recurrence_rule" TEXT,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "TimeBlock_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "TimeBlock_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TimeBlock_pkey" PRIMARY KEY ("id")
 );
 
--- Planning session table
+-- CreateTable
+CREATE TABLE "Channel" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "visibility" "ChannelVisibility" NOT NULL DEFAULT 'private',
+    "target_calendar_id" TEXT,
+    "color" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Channel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "PlanningSession" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "type" "PlanningSessionType" NOT NULL,
-    "started_at" TIMESTAMPTZ NOT NULL,
-    "completed_at" TIMESTAMPTZ,
+    "started_at" TIMESTAMP(3) NOT NULL,
+    "completed_at" TIMESTAMP(3),
     "context" "PlanningContext" NOT NULL,
     "source" "PlanningSource" NOT NULL,
     "notes" TEXT,
-    CONSTRAINT "PlanningSession_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+
+    CONSTRAINT "PlanningSession_pkey" PRIMARY KEY ("id")
 );
 
--- Objective table
+-- CreateTable
 CREATE TABLE "Objective" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "type" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "description" TEXT,
-    "target_week" TIMESTAMPTZ,
+    "target_week" TIMESTAMP(3),
     "status" TEXT,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "Objective_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Objective_pkey" PRIMARY KEY ("id")
 );
 
--- Focus session table
+-- CreateTable
 CREATE TABLE "FocusSession" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "task_id" TEXT NOT NULL,
-    "start_at" TIMESTAMPTZ NOT NULL,
-    "end_at" TIMESTAMPTZ NOT NULL,
+    "start_at" TIMESTAMP(3) NOT NULL,
+    "end_at" TIMESTAMP(3) NOT NULL,
     "planned_minutes" INTEGER NOT NULL,
     "actual_minutes" INTEGER,
     "status" "FocusSessionStatus" NOT NULL DEFAULT 'active',
     "interruptions" JSONB,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "FocusSession_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "FocusSession_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FocusSession_pkey" PRIMARY KEY ("id")
 );
 
--- Calendar integration table
+-- CreateTable
 CREATE TABLE "CalendarIntegration" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "provider" "Provider" NOT NULL,
     "access_token" TEXT NOT NULL,
     "refresh_token" TEXT,
-    "expires_at" TIMESTAMPTZ,
+    "expires_at" TIMESTAMP(3),
     "sync_state" JSONB,
     "sync_mode" "SyncMode" NOT NULL DEFAULT 'polling',
     "calendar_id" TEXT,
-    CONSTRAINT "CalendarIntegration_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+
+    CONSTRAINT "CalendarIntegration_pkey" PRIMARY KEY ("id")
 );
 
--- Audit log table
+-- CreateTable
 CREATE TABLE "AuditLog" (
-    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
     "action" TEXT NOT NULL,
     "entity_type" TEXT NOT NULL,
     "entity_id" TEXT NOT NULL,
     "metadata" JSONB,
-    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT "AuditLog_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
 );
 
--- Indexes
-CREATE INDEX "Task_user_status_idx" ON "Task"("user_id", "status");
-CREATE INDEX "Task_user_priority_score_idx" ON "Task"("user_id", "priority_score" DESC);
-CREATE INDEX "Task_user_due_idx" ON "Task"("user_id", "due_at");
-CREATE INDEX "Task_user_channel_idx" ON "Task"("user_id", "channel_id");
-CREATE INDEX "Task_labels_gin" ON "Task" USING GIN ("labels");
-CREATE INDEX "Subtask_task_order_idx" ON "Subtask"("task_id", "order");
-CREATE INDEX "TimeBlock_user_time_idx" ON "TimeBlock"("user_id", "start_at", "end_at");
-CREATE INDEX "PlanningSession_user_started_idx" ON "PlanningSession"("user_id", "started_at" DESC);
-CREATE INDEX "FocusSession_user_started_idx" ON "FocusSession"("user_id", "start_at" DESC);
-CREATE INDEX "CalendarIntegration_user_provider_idx" ON "CalendarIntegration"("user_id", "provider");
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE INDEX "Task_user_id_status_idx" ON "Task"("user_id", "status");
+
+-- CreateIndex
+CREATE INDEX "Task_user_id_priority_score_idx" ON "Task"("user_id", "priority_score" DESC);
+
+-- CreateIndex
+CREATE INDEX "Task_user_id_due_at_idx" ON "Task"("user_id", "due_at");
+
+-- CreateIndex
+CREATE INDEX "Task_user_id_channel_id_idx" ON "Task"("user_id", "channel_id");
+
+-- CreateIndex
+CREATE INDEX "Task_labels_idx" ON "Task" USING GIN ("labels");
+
+-- CreateIndex
+CREATE INDEX "Subtask_task_id_order_idx" ON "Subtask"("task_id", "order");
+
+-- CreateIndex
+CREATE INDEX "TimeBlock_user_id_start_at_end_at_idx" ON "TimeBlock"("user_id", "start_at", "end_at");
+CREATE INDEX "TimeBlock_user_id_channel_id_idx" ON "TimeBlock"("user_id", "channel_id");
+
+-- CreateIndex
+CREATE INDEX "PlanningSession_user_id_started_at_idx" ON "PlanningSession"("user_id", "started_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "FocusSession_user_id_start_at_idx" ON "FocusSession"("user_id", "start_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "CalendarIntegration_user_id_provider_idx" ON "CalendarIntegration"("user_id", "provider");
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_channel_id_fkey" FOREIGN KEY ("channel_id") REFERENCES "Channel"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subtask" ADD CONSTRAINT "Subtask_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskImport" ADD CONSTRAINT "TaskImport_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskImport" ADD CONSTRAINT "TaskImport_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TimeBlock" ADD CONSTRAINT "TimeBlock_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TimeBlock" ADD CONSTRAINT "TimeBlock_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "TimeBlock" ADD CONSTRAINT "TimeBlock_channel_id_fkey" FOREIGN KEY ("channel_id") REFERENCES "Channel"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Channel" ADD CONSTRAINT "Channel_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PlanningSession" ADD CONSTRAINT "PlanningSession_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Objective" ADD CONSTRAINT "Objective_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FocusSession" ADD CONSTRAINT "FocusSession_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FocusSession" ADD CONSTRAINT "FocusSession_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CalendarIntegration" ADD CONSTRAINT "CalendarIntegration_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/backend/prisma/migrations/0002_calendar_sync/migration.sql
+++ b/backend/prisma/migrations/0002_calendar_sync/migration.sql
@@ -1,0 +1,2 @@
+-- Add unique constraint for synced calendar events per user
+CREATE UNIQUE INDEX "TimeBlock_user_id_calendar_event_id_key" ON "TimeBlock"("user_id","calendar_event_id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -79,7 +79,6 @@ model User {
 
   tasks               Task[]
   task_imports        TaskImport[]
-  subtasks            Subtask[]
   time_blocks         TimeBlock[]
   channels            Channel[]
   planning_sessions   PlanningSession[]
@@ -155,6 +154,8 @@ model TimeBlock {
   user_id            String
   task               Task?           @relation(fields: [task_id], references: [id])
   task_id            String?
+  channel            Channel?        @relation(fields: [channel_id], references: [id])
+  channel_id         String?
   start_at           DateTime
   end_at             DateTime
   status             TimeBlockStatus @default(tentative)
@@ -167,6 +168,8 @@ model TimeBlock {
   updated_at         DateTime        @updatedAt
 
   @@index([user_id, start_at, end_at])
+  @@index([user_id, channel_id])
+  @@unique([user_id, calendar_event_id])
 }
 
 model Channel {
@@ -181,6 +184,7 @@ model Channel {
   updated_at         DateTime          @updatedAt
 
   tasks              Task[]
+  time_blocks        TimeBlock[]
 }
 
 model PlanningSession {

--- a/backend/src/__tests__/digests.test.ts
+++ b/backend/src/__tests__/digests.test.ts
@@ -1,0 +1,104 @@
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import type { PrismaClient } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildDailyDigest } from '../jobs/digests';
+
+let prisma: PrismaClient;
+let schema: string;
+let skipSuite = false;
+
+beforeAll(async () => {
+  const baseDatabaseUrl =
+    process.env.TEST_DATABASE_URL ||
+    'postgresql://app:password@localhost:5432/app_db';
+  schema = `test_${randomUUID().replace(/-/g, '')}`;
+  const databaseUrl = `${baseDatabaseUrl}?schema=${schema}`;
+  process.env.DATABASE_URL = databaseUrl;
+
+  try {
+    execSync('npx prisma migrate deploy', {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      stdio: 'inherit',
+    });
+
+    ({ prisma } = await import('../lib/prisma'));
+  } catch (error) {
+    skipSuite = true;
+  }
+});
+
+afterAll(async () => {
+  if (skipSuite || !prisma) {
+    return;
+  }
+
+  await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  await prisma.$disconnect();
+});
+
+describe('daily digests', () => {
+  it('summarizes tasks and stale calendar syncs', async () => {
+    if (skipSuite) {
+      return;
+    }
+
+    const today = new Date('2024-02-02T12:00:00Z');
+
+    const user = await prisma.user.create({
+      data: { email: 'digest@example.com', display_name: 'Digest User' },
+    });
+
+    await prisma.task.createMany({
+      data: [
+        {
+          id: randomUUID(),
+          user_id: user.id,
+          title: 'Due today',
+          status: 'todo',
+          due_at: new Date('2024-02-02T09:00:00Z'),
+        },
+        {
+          id: randomUUID(),
+          user_id: user.id,
+          title: 'Tomorrow',
+          status: 'todo',
+          due_at: new Date('2024-02-03T09:00:00Z'),
+        },
+        {
+          id: randomUUID(),
+          user_id: user.id,
+          title: 'Done already',
+          status: 'done',
+          due_at: new Date('2024-02-02T10:00:00Z'),
+        },
+      ],
+    });
+
+    await prisma.calendarIntegration.create({
+      data: {
+        user_id: user.id,
+        provider: 'google',
+        access_token: 'token',
+        sync_state: { lastSyncAt: '2024-01-31T10:00:00Z' },
+        sync_mode: 'polling',
+      },
+    });
+
+    await prisma.calendarIntegration.create({
+      data: {
+        user_id: user.id,
+        provider: 'google',
+        access_token: 'token',
+        sync_state: { lastSyncAt: '2024-02-02T08:00:00Z' },
+        sync_mode: 'polling',
+      },
+    });
+
+    const digest = await buildDailyDigest(today);
+
+    expect(digest.dueToday).toBe(1);
+    expect(digest.staleIntegrations).toBe(1);
+    expect(digest.affectedUserIds).toEqual([user.id]);
+  });
+});

--- a/backend/src/__tests__/health.test.ts
+++ b/backend/src/__tests__/health.test.ts
@@ -6,6 +6,7 @@ describe('health endpoint', () => {
   it('responds with status ok', async () => {
     const response = await request(app).get('/health');
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({ status: 'ok' });
+    expect(response.body.status).toBe('ok');
+    expect(response.body.checks).toEqual({ db: 'skipped', redis: 'skipped' });
   });
 });

--- a/backend/src/__tests__/planning-focus.integration.test.ts
+++ b/backend/src/__tests__/planning-focus.integration.test.ts
@@ -1,0 +1,145 @@
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import type { Express } from 'express';
+import request from 'supertest';
+import type { PrismaClient } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+let app: Express;
+let prisma: PrismaClient;
+let schema: string;
+let skipSuite = false;
+
+beforeAll(async () => {
+  const baseDatabaseUrl =
+    process.env.TEST_DATABASE_URL || 'postgresql://app:password@localhost:5432/app_db';
+  schema = `test_${randomUUID().replace(/-/g, '')}`;
+  const databaseUrl = `${baseDatabaseUrl}?schema=${schema}`;
+  process.env.DATABASE_URL = databaseUrl;
+
+  try {
+    execSync('npx prisma migrate deploy', {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      stdio: 'inherit',
+    });
+
+    const appModule = await import('../app');
+    ({ prisma } = await import('../lib/prisma'));
+    app = appModule.default;
+  } catch (error) {
+    skipSuite = true;
+  }
+});
+
+afterAll(async () => {
+  if (skipSuite || !prisma) {
+    return;
+  }
+
+  await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+  await prisma.$disconnect();
+});
+
+describe('planning rituals and focus mode', () => {
+  it('captures a planning session with planned tasks and reflections', async () => {
+    if (skipSuite) return;
+
+    const user = await prisma.user.create({
+      data: { email: 'planner@example.com', display_name: 'Planner' },
+    });
+
+    const [taskA, taskB] = await prisma.$transaction([
+      prisma.task.create({
+        data: { user_id: user.id, title: 'Prioritize bugs', priority_level: 3 },
+      }),
+      prisma.task.create({
+        data: { user_id: user.id, title: 'Prep weekly doc', priority_level: 2 },
+      }),
+    ]);
+
+    const objective = await prisma.objective.create({
+      data: {
+        user_id: user.id,
+        title: 'Ship planning doc',
+        type: 'weekly',
+        status: 'planned',
+      },
+    });
+
+    const startResponse = await request(app).post('/planning-sessions').send({
+      userId: user.id,
+      type: 'morning',
+      context: 'work',
+      plannedTaskIds: [taskA.id, taskB.id],
+    });
+
+    expect(startResponse.status).toBe(201);
+    expect(startResponse.body.status).toBe('in_progress');
+    expect(startResponse.body.plannedTaskIds).toEqual(
+      expect.arrayContaining([taskA.id, taskB.id])
+    );
+
+    const updatedTask = await prisma.task.findUnique({ where: { id: taskA.id } });
+    expect(updatedTask?.planned_sessions).toContain(startResponse.body.id);
+
+    const completeResponse = await request(app)
+      .patch(`/planning-sessions/${startResponse.body.id}/complete`)
+      .send({
+        reflection: 'Today went well',
+        highlightTaskId: taskA.id,
+        objectiveIds: [objective.id],
+      });
+
+    expect(completeResponse.status).toBe(200);
+    expect(completeResponse.body.status).toBe('completed');
+    expect(completeResponse.body.reflection).toBe('Today went well');
+
+    const refreshedObjective = await prisma.objective.findUnique({ where: { id: objective.id } });
+    expect(refreshedObjective?.status).toBe('active');
+
+    const highlightedTask = await prisma.task.findUnique({ where: { id: taskA.id } });
+    expect(highlightedTask?.priority_level).toBe(5);
+  });
+
+  it('runs a focus session, books a block, and logs actual time', async () => {
+    if (skipSuite) return;
+
+    const user = await prisma.user.create({
+      data: { email: 'focus@example.com', display_name: 'Focus User' },
+    });
+
+    const [task, channel] = await prisma.$transaction([
+      prisma.task.create({
+        data: { user_id: user.id, title: 'Deep work task', priority_level: 4 },
+      }),
+      prisma.channel.create({ data: { user_id: user.id, name: 'Deep Work' } }),
+    ]);
+
+    const createResponse = await request(app).post('/focus-sessions').send({
+      userId: user.id,
+      taskId: task.id,
+      plannedMinutes: 25,
+      channelId: channel.id,
+      goal: 'Ship draft',
+    });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.status).toBe('active');
+    expect(createResponse.body.goal).toBe('Ship draft');
+
+    const blocks = await prisma.timeBlock.findMany({ where: { task_id: task.id } });
+    expect(blocks).toHaveLength(1);
+
+    const completeResponse = await request(app)
+      .patch(`/focus-sessions/${createResponse.body.id}/complete`)
+      .send({ actualMinutes: 20, summary: 'Done', interruptions: 1 });
+
+    expect(completeResponse.status).toBe(200);
+    expect(completeResponse.body.actualMinutes).toBe(20);
+    expect(completeResponse.body.status).toBe('completed');
+
+    const taskWithActuals = await prisma.task.findUnique({ where: { id: task.id } });
+    expect(taskWithActuals?.actual_minutes).toBe(20);
+  });
+});
+

--- a/backend/src/__tests__/tasks.integration.test.ts
+++ b/backend/src/__tests__/tasks.integration.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import type { Express } from 'express';
 import request from 'supertest';
 import type { PrismaClient } from '@prisma/client';
+import { Provider } from '@prisma/client';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 let app: Express;
@@ -86,5 +87,97 @@ describe('tasks integration', () => {
 
     const deleteResponse = await request(app).delete(`/tasks/${taskId}`);
     expect(deleteResponse.status).toBe(204);
+
+    const auditLogs = await prisma.auditLog.findMany({
+      where: { user_id: user.id },
+      orderBy: { created_at: 'asc' },
+    });
+
+    expect(auditLogs.map((log) => log.action)).toEqual([
+      'task.created',
+      'task.updated',
+      'task.priority',
+      'task.deleted',
+    ]);
+  });
+
+  it('computes priority scores and filters by schedule/channel', async () => {
+    if (skipSuite) {
+      return;
+    }
+
+    const user = await prisma.user.create({
+      data: {
+        email: 'priority@example.com',
+        display_name: 'Priority User',
+      },
+    });
+
+    const channel = await prisma.channel.create({
+      data: { name: 'Work', user_id: user.id },
+    });
+
+    const [highScore, midScore, unscheduled] = await Promise.all([
+      request(app).post('/tasks').send({
+        userId: user.id,
+        title: 'High importance',
+        importance: 5,
+        urgency: 2,
+        dueAt: new Date(Date.now() + 86400000).toISOString(),
+        channelId: channel.id,
+      }),
+      request(app).post('/tasks').send({
+        userId: user.id,
+        title: 'Urgent',
+        importance: 2,
+        urgency: 5,
+        dueAt: new Date(Date.now() + 2 * 86400000).toISOString(),
+      }),
+      request(app).post('/tasks').send({
+        userId: user.id,
+        title: 'No blocks',
+        priorityLevel: 2,
+      }),
+    ]);
+
+    expect(highScore.body.priorityScore).toBeGreaterThan(midScore.body.priorityScore);
+
+    await prisma.timeBlock.create({
+      data: {
+        user_id: user.id,
+        task_id: highScore.body.id,
+        start_at: new Date(),
+        end_at: new Date(Date.now() + 30 * 60000),
+        provider: Provider.local,
+      },
+    });
+
+    const sorted = await request(app)
+      .get('/tasks')
+      .query({ userId: user.id });
+
+    expect(sorted.body[0].id).toBe(highScore.body.id);
+
+    const scheduledOnly = await request(app)
+      .get('/tasks')
+      .query({ userId: user.id, scheduled: 'scheduled' });
+
+    expect(scheduledOnly.body).toHaveLength(1);
+    expect(scheduledOnly.body[0].id).toBe(highScore.body.id);
+
+    const channelFiltered = await request(app)
+      .get('/tasks')
+      .query({ userId: user.id, channelId: channel.id });
+
+    expect(channelFiltered.body).toHaveLength(1);
+    expect(channelFiltered.body[0].id).toBe(highScore.body.id);
+
+    const unscheduledOnly = await request(app)
+      .get('/tasks')
+      .query({ userId: user.id, scheduled: 'unscheduled' });
+
+    const ids = unscheduledOnly.body.map((task: { id: string }) => task.id);
+    expect(ids).toContain(midScore.body.id);
+    expect(ids).toContain(unscheduled.body.id);
   });
 });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,14 +1,58 @@
 import express from 'express';
+import { logError } from './lib/logger';
+import { prisma } from './lib/prisma';
+import { pingRedis } from './lib/redis';
 import { errorHandler } from './middleware/error-handler';
 import { requestLogger } from './middleware/request-logger';
 import router from './routes';
+
+type HealthStatus = 'up' | 'down' | 'skipped';
+
+const shouldSkipHealthChecks = () =>
+  process.env.HEALTHCHECK_SKIP_DEPENDENCIES === 'true' || process.env.NODE_ENV === 'test';
+
+const checkDatabase = async (): Promise<HealthStatus> => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return 'up';
+  } catch (error) {
+    logError({ message: 'database_health_check_failed', error });
+    return 'down';
+  }
+};
+
+const checkRedis = async (): Promise<HealthStatus> => {
+  try {
+    return await pingRedis();
+  } catch (error) {
+    logError({ message: 'redis_health_check_failed', error });
+    return 'down';
+  }
+};
+
+const buildHealthChecks = async () => {
+  if (shouldSkipHealthChecks()) {
+    return { db: 'skipped', redis: 'skipped' } as const;
+  }
+
+  const [db, redis] = await Promise.all([checkDatabase(), checkRedis()]);
+  return { db, redis } as const;
+};
 
 const app = express();
 app.use(express.json());
 app.use(requestLogger);
 
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
+app.get('/health', async (_req, res) => {
+  const checks = await buildHealthChecks();
+  const isHealthy = Object.values(checks).every(
+    (status) => status === 'up' || status === 'skipped'
+  );
+
+  res.json({
+    status: isHealthy ? 'ok' : 'degraded',
+    checks,
+  });
 });
 
 app.use(router);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,18 @@
 import app from './app';
+import { startBackgroundJobs } from './jobs';
+import { logError } from './lib/logger';
 
 const port = process.env.PORT || 3001;
 
 if (process.env.NODE_ENV !== 'test') {
+  try {
+    startBackgroundJobs();
+  } catch (error) {
+    logError({
+      message: 'failed_to_start_background_jobs',
+      error,
+    });
+  }
   app.listen(port, () => {
     // eslint-disable-next-line no-console
     console.log(`Backend listening on port ${port}`);

--- a/backend/src/jobs/digests.ts
+++ b/backend/src/jobs/digests.ts
@@ -1,0 +1,71 @@
+import { prisma } from '../lib/prisma';
+import { log } from '../lib/logger';
+import { trackTelemetry } from '../lib/telemetry';
+
+const DAILY_DIGEST_INTERVAL_MS = 1000 * 60 * 60 * 6; // every 6 hours to avoid drift
+let interval: NodeJS.Timeout | null = null;
+
+const startOfUtcDay = (date: Date) => {
+  const copy = new Date(date);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+};
+
+export const buildDailyDigest = async (now = new Date()) => {
+  const start = startOfUtcDay(now);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+
+  const [tasksDueToday, integrations] = await Promise.all([
+    prisma.task.findMany({
+      where: {
+        due_at: { gte: start, lt: end },
+        status: { in: ['todo', 'in_progress'] },
+      },
+    }),
+    prisma.calendarIntegration.findMany(),
+  ]);
+
+  const staleIntegrations = integrations.filter((integration) => {
+    const syncState = (integration.sync_state ?? {}) as Record<string, unknown>;
+    const lastSyncValue = syncState.lastSyncAt as string | undefined;
+    if (!lastSyncValue) return true;
+    const lastSync = new Date(lastSyncValue);
+    const hoursSinceSync = (now.getTime() - lastSync.getTime()) / 3_600_000;
+    return hoursSinceSync > 24;
+  });
+
+  const digest = {
+    date: start.toISOString(),
+    dueToday: tasksDueToday.length,
+    staleIntegrations: staleIntegrations.length,
+    affectedUserIds: Array.from(new Set(staleIntegrations.map((i) => i.user_id))),
+  };
+
+  trackTelemetry('digest.generated', digest);
+  log({ level: 'info', message: 'daily_digest_ready', ...digest });
+
+  return digest;
+};
+
+export const startDigestJob = () => {
+  if (process.env.NODE_ENV === 'test' || interval) {
+    return interval;
+  }
+
+  interval = setInterval(async () => {
+    try {
+      await buildDailyDigest();
+    } catch (error) {
+      log({ level: 'error', message: 'daily_digest_failed', error });
+    }
+  }, DAILY_DIGEST_INTERVAL_MS);
+
+  return interval;
+};
+
+export const stopDigestJob = () => {
+  if (!interval) return;
+  clearInterval(interval);
+  interval = null;
+};

--- a/backend/src/jobs/heartbeat.ts
+++ b/backend/src/jobs/heartbeat.ts
@@ -1,0 +1,32 @@
+import { setInterval } from 'node:timers';
+import { log } from '../lib/logger';
+import { pingRedis } from '../lib/redis';
+
+const HEARTBEAT_INTERVAL_MS = 60_000;
+let interval: NodeJS.Timeout | null = null;
+
+export const startHeartbeatJob = () => {
+  if (interval) {
+    return interval;
+  }
+
+  interval = setInterval(async () => {
+    const redisStatus = await pingRedis();
+    log({
+      level: 'info',
+      message: 'heartbeat_job',
+      redisStatus,
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+
+  return interval;
+};
+
+export const stopHeartbeatJob = () => {
+  if (!interval) {
+    return;
+  }
+
+  clearInterval(interval);
+  interval = null;
+};

--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -1,0 +1,9 @@
+import { startHeartbeatJob } from './heartbeat';
+import { startRolloverJob } from './rollover';
+import { startDigestJob } from './digests';
+
+export const startBackgroundJobs = () => {
+  startHeartbeatJob();
+  startRolloverJob();
+  startDigestJob();
+};

--- a/backend/src/jobs/rollover.ts
+++ b/backend/src/jobs/rollover.ts
@@ -1,0 +1,64 @@
+import { prisma } from '../lib/prisma';
+
+const startOfToday = (now: Date) => {
+  const copy = new Date(now);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+};
+
+export const rolloverIncompleteTasks = async (now = new Date()) => {
+  const today = startOfToday(now);
+
+  const candidates = await prisma.task.findMany({
+    where: {
+      status: { in: ['todo', 'in_progress'] },
+      due_at: { lt: today },
+    },
+  });
+
+  await Promise.all(
+    candidates.map((task) =>
+      prisma.task.update({
+        where: { id: task.id },
+        data: {
+          status: 'todo',
+          due_at: today,
+          rollover_state: {
+            rolledFrom: task.due_at,
+            rolledAt: now.toISOString(),
+            previousSessions: task.planned_sessions,
+          },
+        },
+      })
+    )
+  );
+
+  return candidates.length;
+};
+
+export const startRolloverJob = () => {
+  if (process.env.NODE_ENV === 'test') return;
+
+  const scheduleNextRun = () => {
+    const now = new Date();
+    const next = new Date(now);
+    next.setUTCHours(24, 0, 5, 0);
+    const delay = Math.max(next.getTime() - now.getTime(), 1000 * 60 * 60);
+
+    setTimeout(async () => {
+      try {
+        const count = await rolloverIncompleteTasks();
+        if (count > 0) {
+          console.info(`[rollover] carried ${count} tasks forward`);
+        }
+      } catch (error) {
+        console.error('[rollover] failed to process tasks', error);
+      } finally {
+        scheduleNextRun();
+      }
+    }, delay);
+  };
+
+  scheduleNextRun();
+};
+

--- a/backend/src/lib/audit.ts
+++ b/backend/src/lib/audit.ts
@@ -1,0 +1,39 @@
+import { prisma } from './prisma';
+import { log } from './logger';
+
+export interface AuditEntry {
+  userId: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  metadata?: Record<string, unknown>;
+}
+
+export const recordAuditLog = async ({
+  userId,
+  action,
+  entityType,
+  entityId,
+  metadata,
+}: AuditEntry) => {
+  const entry = await prisma.auditLog.create({
+    data: {
+      user_id: userId,
+      action,
+      entity_type: entityType,
+      entity_id: entityId,
+      metadata: metadata ?? {},
+    },
+  });
+
+  log({
+    level: 'info',
+    message: 'audit_log_recorded',
+    userId,
+    action,
+    entityType,
+    entityId,
+  });
+
+  return entry;
+};

--- a/backend/src/lib/prisma-enums.ts
+++ b/backend/src/lib/prisma-enums.ts
@@ -17,3 +17,8 @@ export const ProviderEnum = {
   local: 'local',
 } as const;
 
+export const ChannelVisibilityEnum = {
+  private: 'private',
+  shared: 'shared',
+} as const;
+

--- a/backend/src/lib/redis.ts
+++ b/backend/src/lib/redis.ts
@@ -1,0 +1,43 @@
+import { connect } from 'node:net';
+
+type RedisHealth = 'up' | 'down';
+
+const DEFAULT_REDIS_URL = 'redis://localhost:6379';
+
+const getRedisUrl = () => process.env.REDIS_URL ?? DEFAULT_REDIS_URL;
+
+export const pingRedis = async (): Promise<RedisHealth> => {
+  const redisUrl = new URL(getRedisUrl());
+  const port = Number(redisUrl.port || 6379);
+
+  return new Promise<RedisHealth>((resolve) => {
+    const socket = connect({ host: redisUrl.hostname, port });
+    const cleanup = () => {
+      socket.removeAllListeners();
+      socket.destroy();
+    };
+
+    const resolveDown = () => {
+      cleanup();
+      resolve('down');
+    };
+
+    socket.on('connect', () => {
+      socket.write('*1\r\n$4\r\nPING\r\n');
+    });
+
+    socket.on('data', (data) => {
+      const isPong = data.toString().toUpperCase().includes('PONG');
+      cleanup();
+      resolve(isPong ? 'up' : 'down');
+    });
+
+    socket.on('error', resolveDown);
+    socket.on('timeout', resolveDown);
+    socket.setTimeout(500);
+  });
+};
+
+export const getRedisConfig = () => ({
+  url: getRedisUrl(),
+});

--- a/backend/src/lib/telemetry.ts
+++ b/backend/src/lib/telemetry.ts
@@ -1,0 +1,17 @@
+import { log } from './logger';
+
+export type TelemetryEvent =
+  | 'task.created'
+  | 'task.updated'
+  | 'task.deleted'
+  | 'task.priority'
+  | 'timeblock.created'
+  | 'calendar.sync'
+  | 'digest.generated';
+
+export const trackTelemetry = (
+  event: TelemetryEvent,
+  properties?: Record<string, unknown>
+) => {
+  log({ level: 'info', message: 'telemetry_event', event, ...properties });
+};

--- a/backend/src/modules/channels/__tests__/channels.router.test.ts
+++ b/backend/src/modules/channels/__tests__/channels.router.test.ts
@@ -1,0 +1,138 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { errorHandler } from '../../../middleware/error-handler';
+import channelsRouter from '../channels.router';
+
+vi.mock('../../../lib/prisma', () => {
+  const create = vi.fn();
+  const findMany = vi.fn();
+  const update = vi.fn();
+  const deleteMock = vi.fn();
+
+  return {
+    prisma: {
+      channel: { create, findMany, update, delete: deleteMock },
+    },
+  };
+});
+
+const { prisma } = await import('../../../lib/prisma');
+
+const createApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/channels', channelsRouter);
+  app.use(errorHandler);
+  return app;
+};
+
+describe('channels router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a channel with defaults', async () => {
+    const app = createApp();
+    const mockChannel = {
+      id: 'chan-1',
+      user_id: '0f750c9f-4b5e-4a46-a95e-5c2ebaa6c6b2',
+      name: 'Deep work',
+      visibility: 'private',
+      target_calendar_id: null,
+      color: '#8b5cf6',
+      created_at: new Date('2024-01-01T10:00:00.000Z'),
+      updated_at: new Date('2024-01-01T10:00:00.000Z'),
+    };
+
+    prisma.channel.create.mockResolvedValue(mockChannel);
+
+    const response = await request(app).post('/channels').send({
+      userId: mockChannel.user_id,
+      name: mockChannel.name,
+      color: mockChannel.color,
+    });
+
+    expect(response.status).toBe(201);
+    expect(prisma.channel.create).toHaveBeenCalledWith({
+      data: {
+        user_id: mockChannel.user_id,
+        name: mockChannel.name,
+        visibility: 'private',
+        target_calendar_id: undefined,
+        color: mockChannel.color,
+      },
+    });
+    expect(response.body).toMatchObject({
+      id: mockChannel.id,
+      userId: mockChannel.user_id,
+      name: mockChannel.name,
+      color: mockChannel.color,
+    });
+  });
+
+  it('lists channels for a user', async () => {
+    const app = createApp();
+    const channels = [
+      {
+        id: 'chan-2',
+        user_id: '0f750c9f-4b5e-4a46-a95e-5c2ebaa6c6b2',
+        name: 'Meetings',
+        visibility: 'shared',
+        target_calendar_id: 'cal-123',
+        color: '#22c55e',
+        created_at: new Date('2024-01-02T10:00:00.000Z'),
+        updated_at: new Date('2024-01-02T10:00:00.000Z'),
+      },
+    ];
+
+    prisma.channel.findMany.mockResolvedValue(channels);
+
+    const response = await request(app)
+      .get('/channels')
+      .query({ userId: channels[0].user_id });
+
+    expect(prisma.channel.findMany).toHaveBeenCalledWith({
+      where: { user_id: channels[0].user_id },
+      orderBy: { created_at: 'asc' },
+    });
+    expect(response.status).toBe(200);
+    expect(response.body[0]).toMatchObject({
+      id: channels[0].id,
+      visibility: channels[0].visibility,
+    });
+  });
+
+  it('updates a channel', async () => {
+    const app = createApp();
+    const updated = {
+      id: '00000000-1111-2222-8333-444444444444',
+      user_id: '0f750c9f-4b5e-4a46-a95e-5c2ebaa6c6b2',
+      name: 'Personal focus',
+      visibility: 'private',
+      target_calendar_id: null,
+      color: '#f59e0b',
+      created_at: new Date('2024-01-02T10:00:00.000Z'),
+      updated_at: new Date('2024-01-03T10:00:00.000Z'),
+    };
+
+    prisma.channel.update.mockResolvedValue(updated);
+
+    const response = await request(app).patch(`/channels/${updated.id}`).send({
+      name: updated.name,
+      color: updated.color,
+    });
+
+    expect(prisma.channel.update).toHaveBeenCalledWith({
+      where: { id: updated.id },
+      data: {
+        name: updated.name,
+        visibility: undefined,
+        target_calendar_id: undefined,
+        color: updated.color,
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ name: updated.name });
+  });
+});

--- a/backend/src/modules/channels/channels.router.ts
+++ b/backend/src/modules/channels/channels.router.ts
@@ -1,0 +1,152 @@
+import { Prisma, type Channel, type ChannelVisibility } from '@prisma/client';
+import { Router } from 'express';
+import { ChannelVisibilityEnum } from '../../lib/prisma-enums';
+import { HttpError } from '../../lib/http-error';
+import { prisma } from '../../lib/prisma';
+import { validateRequest } from '../../middleware/validate-request';
+import { z } from '../../lib/zod';
+
+const toChannelResponse = (channel: Channel) => ({
+  id: channel.id,
+  userId: channel.user_id,
+  name: channel.name,
+  visibility: channel.visibility,
+  targetCalendarId: channel.target_calendar_id ?? null,
+  color: channel.color ?? null,
+  createdAt: channel.created_at?.toISOString(),
+  updatedAt: channel.updated_at?.toISOString(),
+});
+
+const channelsRouter = Router();
+
+const hexColorSchema = z
+  .string()
+  .refine((value) => /^#(?:[0-9a-fA-F]{3}){1,2}$/.test(value), {
+    message: 'color must be a hex value like #7755ff',
+    path: ['color'],
+  });
+
+const createChannelSchema = {
+  body: z.object({
+    userId: z.string().uuid(),
+    name: z.string().min(1),
+    visibility: z
+      .nativeEnum(ChannelVisibilityEnum)
+      .default(ChannelVisibilityEnum.private as ChannelVisibility),
+    targetCalendarId: z.string().optional(),
+    color: hexColorSchema.optional(),
+  }),
+};
+
+const listChannelsSchema = {
+  query: z.object({ userId: z.string().uuid() }),
+};
+
+const channelIdSchema = { params: z.object({ id: z.string().uuid() }) };
+
+const updateChannelSchema = {
+  ...channelIdSchema,
+  body: z
+    .object({
+      name: z.string().min(1).optional(),
+      visibility: z.nativeEnum(ChannelVisibilityEnum).optional(),
+      targetCalendarId: z.string().optional().nullable(),
+      color: hexColorSchema.optional().nullable(),
+    })
+    .refine(
+      (body) => Object.values(body).some((value) => value !== undefined),
+      { message: 'No changes provided', path: ['name'] }
+    ),
+};
+
+const handleNotFound = (id: string) => new HttpError(404, `Channel ${id} not found`);
+
+const handleKnownError = (error: unknown, id?: string) => {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (id && error.code === 'P2025') {
+      return handleNotFound(id);
+    }
+    if (error.code === 'P2003') {
+      return new HttpError(400, 'User not found for channel');
+    }
+  }
+  return error;
+};
+
+channelsRouter.post('/', validateRequest(createChannelSchema), async (req, res, next) => {
+  const { userId, name, visibility, targetCalendarId, color } = req.body;
+
+  try {
+    const channel = await prisma.channel.create({
+      data: {
+        user_id: userId,
+        name,
+        visibility,
+        target_calendar_id: targetCalendarId,
+        color,
+      },
+    });
+
+    res.status(201).json(toChannelResponse(channel));
+  } catch (error) {
+    next(handleKnownError(error));
+  }
+});
+
+channelsRouter.get('/', validateRequest(listChannelsSchema), async (req, res, next) => {
+  const { userId } = req.query as { userId: string };
+
+  try {
+    const channels = await prisma.channel.findMany({
+      where: { user_id: userId },
+      orderBy: { created_at: 'asc' },
+    });
+
+    res.json(channels.map(toChannelResponse));
+  } catch (error) {
+    next(error);
+  }
+});
+
+channelsRouter.patch(
+  '/:id',
+  validateRequest(updateChannelSchema),
+  async (req, res, next) => {
+    const { id } = req.params;
+    const { name, visibility, targetCalendarId, color } = req.body;
+
+    try {
+      const channel = await prisma.channel.update({
+        where: { id },
+        data: {
+          name,
+          visibility,
+          target_calendar_id:
+            targetCalendarId === undefined ? undefined : targetCalendarId,
+          color: color === undefined ? undefined : color,
+        },
+      });
+
+      res.json(toChannelResponse(channel));
+    } catch (error) {
+      next(handleKnownError(error, id));
+    }
+  }
+);
+
+channelsRouter.delete(
+  '/:id',
+  validateRequest(channelIdSchema),
+  async (req, res, next) => {
+    const { id } = req.params;
+
+    try {
+      await prisma.channel.delete({ where: { id } });
+      res.status(204).send();
+    } catch (error) {
+      next(handleKnownError(error, id));
+    }
+  }
+);
+
+export default channelsRouter;

--- a/backend/src/modules/sync/__tests__/google.router.test.ts
+++ b/backend/src/modules/sync/__tests__/google.router.test.ts
@@ -1,0 +1,143 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { errorHandler } from '../../../middleware/error-handler';
+import { ProviderEnum, TimeBlockStatusEnum } from '../../../lib/prisma-enums';
+import syncProviderRouter from '../providers/google.router';
+
+vi.mock('../../../lib/prisma', () => {
+  const calendarFindFirst = vi.fn();
+  const calendarUpsert = vi.fn();
+  const calendarDeleteMany = vi.fn();
+  const calendarUpdate = vi.fn();
+  const timeBlockUpsert = vi.fn();
+  const channelFindFirst = vi.fn();
+
+  return {
+    prisma: {
+      calendarIntegration: {
+        findFirst: calendarFindFirst,
+        upsert: calendarUpsert,
+        deleteMany: calendarDeleteMany,
+        update: calendarUpdate,
+      },
+      timeBlock: { upsert: timeBlockUpsert },
+      channel: { findFirst: channelFindFirst },
+    },
+  };
+});
+
+const { prisma } = await import('../../../lib/prisma');
+
+const createApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/sync/providers/google', syncProviderRouter);
+  app.use(errorHandler);
+  return app;
+};
+
+describe('google sync router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports disconnected status when no integration exists', async () => {
+    const app = createApp();
+
+    prisma.calendarIntegration.findFirst.mockResolvedValue(null);
+
+    const response = await request(app)
+      .get('/sync/providers/google/status')
+      .query({ userId: '7b9c62e8-1434-4f36-80f6-6a92ad83f3be' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('disconnected');
+  });
+
+  it('polls events and upserts timeblocks tied to calendar channels', async () => {
+    const app = createApp();
+
+    const integration = {
+      id: 'integration-1',
+      user_id: 'f33d5c8b-01d5-4f57-8e8b-395260ae93e7',
+      provider: ProviderEnum.google,
+      access_token: 'token',
+      refresh_token: null,
+      expires_at: null,
+      sync_state: null,
+      sync_mode: 'polling',
+      calendar_id: null,
+    };
+
+    prisma.calendarIntegration.findFirst.mockResolvedValue(integration);
+    prisma.calendarIntegration.update.mockResolvedValue({ ...integration, calendar_id: 'primary' });
+    prisma.channel.findFirst.mockResolvedValue({ id: 'channel-1' });
+    prisma.timeBlock.upsert.mockResolvedValue({
+      id: 'block-1',
+      user_id: integration.user_id,
+      task_id: null,
+      channel_id: 'channel-1',
+      start_at: new Date('2024-05-01T10:00:00.000Z'),
+      end_at: new Date('2024-05-01T11:00:00.000Z'),
+      status: TimeBlockStatusEnum.confirmed,
+      provider: ProviderEnum.google,
+      location: null,
+      notes: 'Synced event',
+      calendar_event_id: 'evt-1',
+      recurrence_rule: null,
+      created_at: new Date('2024-05-01T09:50:00.000Z'),
+      updated_at: new Date('2024-05-01T09:50:00.000Z'),
+    });
+
+    const response = await request(app)
+      .post('/sync/providers/google/poll')
+      .send({
+        userId: integration.user_id,
+        calendarId: 'primary',
+        cursor: 'next-page',
+        events: [
+          {
+            id: 'evt-1',
+            title: 'Team standup',
+            startAt: '2024-05-01T10:00:00.000Z',
+            endAt: '2024-05-01T11:00:00.000Z',
+            status: TimeBlockStatusEnum.confirmed,
+            calendarId: 'primary',
+            notes: 'Synced event',
+          },
+        ],
+      });
+
+    expect(prisma.timeBlock.upsert).toHaveBeenCalledWith({
+      where: {
+        user_id_calendar_event_id: {
+          user_id: integration.user_id,
+          calendar_event_id: 'evt-1',
+        },
+      },
+      update: expect.objectContaining({
+        start_at: new Date('2024-05-01T10:00:00.000Z'),
+        status: TimeBlockStatusEnum.confirmed,
+        channel_id: 'channel-1',
+      }),
+      create: expect.objectContaining({
+        provider: ProviderEnum.google,
+        calendar_event_id: 'evt-1',
+        channel_id: 'channel-1',
+      }),
+    });
+
+    expect(prisma.calendarIntegration.update).toHaveBeenCalledWith({
+      where: { id: integration.id },
+      data: expect.objectContaining({
+        sync_state: expect.objectContaining({ cursor: 'next-page' }),
+        calendar_id: 'primary',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.synced).toBe(1);
+    expect(response.body.timeblocks[0].calendarEventId).toBe('evt-1');
+  });
+});

--- a/backend/src/modules/sync/providers/google.router.ts
+++ b/backend/src/modules/sync/providers/google.router.ts
@@ -1,5 +1,8 @@
+import { Provider, TimeBlockStatus } from '@prisma/client';
 import { Router } from 'express';
 import { prisma } from '../../../lib/prisma';
+import { ProviderEnum, TimeBlockStatusEnum } from '../../../lib/prisma-enums';
+import { HttpError } from '../../../lib/http-error';
 import { z } from '../../../lib/zod';
 import { validateRequest } from '../../../middleware/validate-request';
 
@@ -77,6 +80,180 @@ syncProviderRouter.post(
 
 syncProviderRouter.post('/webhook', (_req, res) => {
   res.json({ provider: 'google', message: 'Webhook received' });
+});
+
+syncProviderRouter.get(
+  '/status',
+  validateRequest({ query: z.object({ userId: z.string().uuid() }) }),
+  async (req, res, next) => {
+    const { userId } = req.query as { userId: string };
+
+    try {
+      const integration = await prisma.calendarIntegration.findFirst({
+        where: { user_id: userId, provider: ProviderEnum.google as Provider },
+      });
+
+      if (!integration) {
+        return res.json({ status: 'disconnected', provider: 'google' });
+      }
+
+      const syncState = (integration.sync_state as Record<string, unknown>) ?? {};
+
+      res.json({
+        status: 'connected',
+        provider: 'google',
+        integrationId: integration.id,
+        lastSyncedAt: syncState.lastSyncAt ?? null,
+        syncMode: integration.sync_mode,
+        calendarId: integration.calendar_id ?? null,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+const pullEventsSchema = {
+  body: z.object({
+    userId: z.string().uuid(),
+    events: z
+      .array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          startAt: z.string().datetime(),
+          endAt: z.string().datetime(),
+          status: z
+            .nativeEnum(TimeBlockStatusEnum)
+            .default(TimeBlockStatusEnum.tentative as TimeBlockStatus),
+          calendarId: z.string().optional(),
+          recurrenceRule: z.string().optional(),
+          location: z.string().optional(),
+          notes: z.string().optional(),
+        })
+      )
+      .default([]),
+    cursor: z.string().optional(),
+    calendarId: z.string().optional(),
+  }),
+};
+
+syncProviderRouter.post(
+  '/poll',
+  validateRequest(pullEventsSchema),
+  async (req, res, next) => {
+    const { userId, events, cursor, calendarId } = req.body;
+
+    try {
+      const integration = await prisma.calendarIntegration.findFirst({
+        where: { user_id: userId, provider: ProviderEnum.google as Provider },
+      });
+
+      if (!integration) {
+        throw new HttpError(404, 'Google integration not found for user');
+      }
+
+      const syncedBlocks = [] as Array<ReturnType<typeof mapToResponse>>;
+
+      for (const event of events) {
+        const channel = event.calendarId
+          ? await prisma.channel.findFirst({
+              where: {
+                user_id: userId,
+                target_calendar_id: event.calendarId,
+              },
+            })
+          : null;
+
+        const timeblock = await prisma.timeBlock.upsert({
+          where: {
+            user_id_calendar_event_id: {
+              user_id: userId,
+              calendar_event_id: event.id,
+            },
+          },
+          update: {
+            start_at: new Date(event.startAt),
+            end_at: new Date(event.endAt),
+            status: event.status,
+            channel_id: channel?.id ?? null,
+            recurrence_rule: event.recurrenceRule ?? null,
+            location: event.location ?? null,
+            notes: event.notes ?? null,
+          },
+          create: {
+            user_id: userId,
+            start_at: new Date(event.startAt),
+            end_at: new Date(event.endAt),
+            status: event.status,
+            provider: ProviderEnum.google as Provider,
+            calendar_event_id: event.id,
+            recurrence_rule: event.recurrenceRule ?? null,
+            location: event.location ?? null,
+            notes: event.notes ?? null,
+            channel_id: channel?.id ?? null,
+          },
+        });
+
+        syncedBlocks.push(mapToResponse(timeblock));
+      }
+
+      const lastSyncAt = new Date().toISOString();
+
+      await prisma.calendarIntegration.update({
+        where: { id: integration.id },
+        data: {
+          calendar_id: calendarId ?? integration.calendar_id,
+          sync_state: {
+            ...(integration.sync_state as Record<string, unknown>),
+            lastSyncAt,
+            cursor: cursor ?? null,
+          },
+        },
+      });
+
+      res.json({
+        provider: 'google',
+        synced: syncedBlocks.length,
+        lastSyncAt,
+        timeblocks: syncedBlocks,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+const mapToResponse = (timeblock: {
+  id: string;
+  user_id: string;
+  task_id?: string | null;
+  channel_id?: string | null;
+  start_at: Date;
+  end_at: Date;
+  status: TimeBlockStatus;
+  provider: Provider;
+  location?: string | null;
+  notes?: string | null;
+  calendar_event_id?: string | null;
+  recurrence_rule?: string | null;
+  created_at?: Date;
+  updated_at?: Date;
+}) => ({
+  id: timeblock.id,
+  userId: timeblock.user_id,
+  taskId: timeblock.task_id ?? null,
+  channelId: timeblock.channel_id ?? null,
+  startAt: timeblock.start_at.toISOString(),
+  endAt: timeblock.end_at.toISOString(),
+  status: timeblock.status,
+  provider: timeblock.provider,
+  location: timeblock.location ?? null,
+  notes: timeblock.notes ?? null,
+  calendarEventId: timeblock.calendar_event_id ?? null,
+  recurrenceRule: timeblock.recurrence_rule ?? null,
+  createdAt: timeblock.created_at?.toISOString(),
+  updatedAt: timeblock.updated_at?.toISOString(),
 });
 
 export default syncProviderRouter;

--- a/backend/src/modules/tasks/priority.ts
+++ b/backend/src/modules/tasks/priority.ts
@@ -1,0 +1,24 @@
+const weightImportance = 0.6;
+const weightUrgency = 0.4;
+
+export const computePriorityScore = (
+  importance?: number,
+  urgency?: number
+): number | null => {
+  if (
+    importance === undefined ||
+    urgency === undefined ||
+    importance === null ||
+    urgency === null
+  ) {
+    return null;
+  }
+
+  const importanceScore = Number(importance);
+  const urgencyScore = Number(urgency);
+  return Number(
+    (importanceScore * weightImportance + urgencyScore * weightUrgency).toFixed(2)
+  );
+};
+
+export const defaultPriorityLevel = 3;

--- a/backend/src/modules/tasks/task.mapper.ts
+++ b/backend/src/modules/tasks/task.mapper.ts
@@ -8,6 +8,7 @@ export interface TaskResponse {
   priorityLevel: number;
   priorityScore: number | null;
   dueAt: string | null;
+  channelId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -20,6 +21,7 @@ export const toTaskResponse = (task: Task): TaskResponse => ({
   priorityLevel: task.priority_level,
   priorityScore: task.priority_score,
   dueAt: task.due_at ? task.due_at.toISOString() : null,
+  channelId: task.channel_id ?? null,
   createdAt: task.created_at.toISOString(),
   updatedAt: task.updated_at.toISOString(),
 });

--- a/backend/src/modules/timeblocks/timeblocks.router.ts
+++ b/backend/src/modules/timeblocks/timeblocks.router.ts
@@ -10,6 +10,7 @@ const toTimeblockResponse = (timeblock: TimeBlock) => ({
   id: timeblock.id,
   userId: timeblock.user_id,
   taskId: timeblock.task_id,
+  channelId: timeblock.channel_id ?? null,
   startAt: timeblock.start_at.toISOString(),
   endAt: timeblock.end_at.toISOString(),
   status: timeblock.status,
@@ -31,6 +32,7 @@ const createTimeblockSchema = {
       startAt: z.string().datetime(),
       endAt: z.string().datetime(),
       taskId: z.string().uuid().optional(),
+      channelId: z.string().uuid().optional(),
       status: z
         .nativeEnum(TimeBlockStatusEnum)
         .default(TimeBlockStatusEnum.tentative as TimeBlockStatus),
@@ -44,11 +46,39 @@ const createTimeblockSchema = {
     ),
 };
 
+const suggestTimeblockSchema = {
+  body: z
+    .object({
+      userId: z.string().uuid(),
+      taskId: z.string().uuid().optional(),
+      channelId: z.string().uuid().optional().nullable(),
+      durationMinutes: z.number().int().min(15).max(8 * 60).default(60),
+      windowStart: z.string().datetime().optional(),
+      windowEnd: z.string().datetime().optional(),
+      preferredStartHour: z.number().int().min(0).max(23).default(9),
+      preferredEndHour: z.number().int().min(1).max(23).default(17),
+    })
+    .refine(
+      ({ windowStart, windowEnd }) => {
+        if (!windowStart || !windowEnd) return true;
+        return new Date(windowEnd) > new Date(windowStart);
+      },
+      { message: 'windowEnd must be after windowStart', path: ['windowEnd'] }
+    )
+    .refine(
+      ({ preferredStartHour, preferredEndHour }) => preferredEndHour > preferredStartHour,
+      { message: 'preferredEndHour must be greater than preferredStartHour', path: ['preferredEndHour'] }
+    ),
+};
+
 const listTimeblocksSchema = {
   query: z.object({
     userId: z.string().uuid(),
     status: z.nativeEnum(TimeBlockStatusEnum).optional(),
     taskId: z.string().uuid().optional(),
+    channelId: z.string().uuid().optional(),
+    from: z.string().datetime().optional(),
+    to: z.string().datetime().optional(),
   }),
 };
 
@@ -63,6 +93,7 @@ const updateTimeblockSchema = {
       startAt: z.string().datetime().optional(),
       endAt: z.string().datetime().optional(),
       taskId: z.string().uuid().optional().nullable(),
+      channelId: z.string().uuid().optional().nullable(),
       status: z.nativeEnum(TimeBlockStatusEnum).optional(),
       provider: z.enum([ProviderEnum.google, ProviderEnum.local]).optional(),
       location: z.string().optional().nullable(),
@@ -80,6 +111,7 @@ const updateTimeblockSchema = {
 };
 
 const parseDate = (value: string) => new Date(value);
+const addDays = (value: Date, days: number) => new Date(value.getTime() + days * 86400000);
 
 const handleNotFound = (id: string) => new HttpError(404, `Timeblock ${id} not found`);
 
@@ -88,24 +120,105 @@ const handlePrismaError = (error: unknown, id: string) => {
     error instanceof Prisma.PrismaClientKnownRequestError &&
     error.code === 'P2025'
   ) {
-    throw handleNotFound(id);
+    return handleNotFound(id);
   }
-  throw error;
+  return error;
+};
+
+const ensureNoConflicts = async (
+  userId: string,
+  startAt: Date,
+  endAt: Date,
+  excludeId?: string
+) => {
+  const conflict = await prisma.timeBlock.findFirst({
+    where: {
+      user_id: userId,
+      status: { not: TimeBlockStatusEnum.cancelled as TimeBlockStatus },
+      ...(excludeId ? { id: { not: excludeId } } : {}),
+      AND: [{ start_at: { lt: endAt } }, { end_at: { gt: startAt } }],
+    },
+    select: { id: true, start_at: true, end_at: true },
+  });
+
+  if (conflict) {
+    throw new HttpError(409, 'Timeblock overlaps with an existing block', {
+      conflict,
+    });
+  }
+};
+
+const findFirstOpenSlot = (
+  busyBlocks: Array<Pick<TimeBlock, 'start_at' | 'end_at'>>, // assumed sorted asc
+  searchStart: Date,
+  searchEnd: Date,
+  preferredStartHour: number,
+  preferredEndHour: number,
+  durationMinutes: number
+): { start: Date; end: Date } | null => {
+  const durationMs = durationMinutes * 60 * 1000;
+
+  const iterateDate = new Date(searchStart);
+  iterateDate.setHours(0, 0, 0, 0);
+
+  while (iterateDate <= searchEnd) {
+    const dayStart = new Date(iterateDate);
+    dayStart.setHours(preferredStartHour, 0, 0, 0);
+
+    const dayEnd = new Date(iterateDate);
+    dayEnd.setHours(preferredEndHour, 0, 0, 0);
+
+    const windowStart = new Date(Math.max(dayStart.getTime(), searchStart.getTime()));
+    const windowEnd = new Date(Math.min(dayEnd.getTime(), searchEnd.getTime()));
+
+    if (windowEnd > windowStart) {
+      const dayBusy = busyBlocks.filter(
+        (block) => block.start_at < windowEnd && block.end_at > windowStart
+      );
+
+      let cursor = windowStart;
+
+      for (const block of dayBusy) {
+        if (block.start_at.getTime() - cursor.getTime() >= durationMs) {
+          return { start: cursor, end: new Date(cursor.getTime() + durationMs) };
+        }
+
+        if (block.end_at > cursor) {
+          cursor = block.end_at;
+        }
+      }
+
+      if (windowEnd.getTime() - cursor.getTime() >= durationMs) {
+        return { start: cursor, end: new Date(cursor.getTime() + durationMs) };
+      }
+    }
+
+    iterateDate.setDate(iterateDate.getDate() + 1);
+  }
+
+  return null;
 };
 
 timeblocksRouter.post(
   '/',
   validateRequest(createTimeblockSchema),
   async (req, res, next) => {
-    const { userId, startAt, endAt, taskId, status, provider } = req.body;
+    const { userId, startAt, endAt, taskId, channelId, status, provider } =
+      req.body;
 
     try {
+      const start = parseDate(startAt);
+      const end = parseDate(endAt);
+
+      await ensureNoConflicts(userId, start, end);
+
       const timeblock = await prisma.timeBlock.create({
         data: {
           user_id: userId,
-          start_at: parseDate(startAt),
-          end_at: parseDate(endAt),
+          start_at: start,
+          end_at: end,
           task_id: taskId ?? null,
+          channel_id: channelId ?? null,
           status,
           provider,
         },
@@ -122,10 +235,13 @@ timeblocksRouter.get(
   '/',
   validateRequest(listTimeblocksSchema),
   async (req, res, next) => {
-    const { userId, status, taskId } = req.query as {
+    const { userId, status, taskId, channelId, from, to } = req.query as {
       userId: string;
       status?: TimeBlockStatus;
       taskId?: string;
+      channelId?: string;
+      from?: string;
+      to?: string;
     };
 
     try {
@@ -134,11 +250,80 @@ timeblocksRouter.get(
           user_id: userId,
           status,
           task_id: taskId,
+          channel_id: channelId,
+          start_at: from ? { gte: parseDate(from) } : undefined,
+          end_at: to ? { lte: parseDate(to) } : undefined,
         },
         orderBy: { start_at: 'asc' },
       });
 
       res.json(timeblocks.map(toTimeblockResponse));
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+timeblocksRouter.post(
+  '/suggest',
+  validateRequest(suggestTimeblockSchema),
+  async (req, res, next) => {
+    const {
+      userId,
+      taskId,
+      channelId,
+      durationMinutes,
+      windowStart,
+      windowEnd,
+      preferredStartHour,
+      preferredEndHour,
+    } = req.body;
+
+    try {
+      const searchStart = windowStart ? parseDate(windowStart) : new Date();
+      const searchEnd = windowEnd ? parseDate(windowEnd) : addDays(searchStart, 7);
+
+      const busyBlocks = await prisma.timeBlock.findMany({
+        where: {
+          user_id: userId,
+          status: { not: TimeBlockStatusEnum.cancelled as TimeBlockStatus },
+          OR: [
+            { start_at: { lte: searchEnd }, end_at: { gte: searchStart } },
+            { end_at: { gte: searchStart } },
+          ],
+        },
+        orderBy: { start_at: 'asc' },
+        select: { start_at: true, end_at: true },
+      });
+
+      const nextSlot = findFirstOpenSlot(
+        busyBlocks,
+        searchStart,
+        searchEnd,
+        preferredStartHour,
+        preferredEndHour,
+        durationMinutes
+      );
+
+      if (!nextSlot) {
+        throw new HttpError(409, 'No available time within the selected window');
+      }
+
+      await ensureNoConflicts(userId, nextSlot.start, nextSlot.end);
+
+      const timeblock = await prisma.timeBlock.create({
+        data: {
+          user_id: userId,
+          task_id: taskId ?? null,
+          channel_id: channelId ?? null,
+          start_at: nextSlot.start,
+          end_at: nextSlot.end,
+          status: TimeBlockStatusEnum.tentative as TimeBlockStatus,
+          provider: ProviderEnum.local as Provider,
+        },
+      });
+
+      res.status(201).json({ suggestion: toTimeblockResponse(timeblock) });
     } catch (error) {
       next(error);
     }
@@ -154,6 +339,7 @@ timeblocksRouter.patch(
       startAt,
       endAt,
       taskId,
+      channelId,
       status,
       provider,
       location,
@@ -163,12 +349,24 @@ timeblocksRouter.patch(
     } = req.body;
 
     try {
+      const existing = await prisma.timeBlock.findUnique({ where: { id } });
+
+      if (!existing) {
+        throw handleNotFound(id);
+      }
+
+      const nextStart = startAt ? parseDate(startAt) : existing.start_at;
+      const nextEnd = endAt ? parseDate(endAt) : existing.end_at;
+
+      await ensureNoConflicts(existing.user_id, nextStart, nextEnd, id);
+
       const updated = await prisma.timeBlock.update({
         where: { id },
         data: {
-          start_at: startAt ? parseDate(startAt) : undefined,
-          end_at: endAt ? parseDate(endAt) : undefined,
+          start_at: startAt ? nextStart : undefined,
+          end_at: endAt ? nextEnd : undefined,
           task_id: taskId === undefined ? undefined : taskId,
+          channel_id: channelId === undefined ? undefined : channelId,
           status,
           provider,
           location: location ?? undefined,

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -7,11 +7,13 @@ import planningSessionRouter from '../modules/planning-sessions/planning-session
 import syncProviderRouter from '../modules/sync/providers/google.router';
 import tasksRouter from '../modules/tasks/tasks.router';
 import timeblocksRouter from '../modules/timeblocks/timeblocks.router';
+import channelsRouter from '../modules/channels/channels.router';
 
 const router = Router();
 
 router.use('/tasks', tasksRouter);
 router.use('/timeblocks', timeblocksRouter);
+router.use('/channels', channelsRouter);
 router.use('/planning-sessions', planningSessionRouter);
 router.use('/focus-sessions', focusSessionRouter);
 router.use('/breaks', breaksRouter);

--- a/frontend/src/components/calendar-schedule.tsx
+++ b/frontend/src/components/calendar-schedule.tsx
@@ -2,16 +2,64 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, {
   DateClickArg,
+  EventClickArg,
   EventDropArg,
   EventInput,
 } from '@fullcalendar/interaction';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
-import { createTimeBlock, fetchTimeBlocks, updateTimeBlock } from '../lib/api';
+import {
+  createChannel,
+  createTimeBlock,
+  fetchCalendarStatus,
+  fetchChannels,
+  fetchTimeBlocks,
+  pollCalendar,
+  connectCalendar,
+  disconnectCalendar,
+  suggestTimeBlock,
+  updateTimeBlock,
+} from '../lib/api';
 import { trackEvent } from '../lib/telemetry';
-import { Task, TimeBlock } from '../types';
+import { Channel, Task, TimeBlock, TimeBlockStatus } from '../types';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+
+const DEFAULT_DURATION_MIN = 60;
+
+const nextStatus = (status: TimeBlockStatus): TimeBlockStatus => {
+  const order: TimeBlockStatus[] = ['tentative', 'confirmed', 'completed'];
+  const idx = order.indexOf(status);
+  return order[(idx + 1) % order.length];
+};
+
+const getChannelColor = (channelId: string | undefined | null, channels: Channel[]) =>
+  channels.find((channel) => channel.id === channelId)?.color ??
+  'rgba(139, 92, 246, 0.9)';
+
+const findConflicts = (blocks: TimeBlock[]) => {
+  const conflicts = new Set<string>();
+  const sorted = [...blocks].sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+  );
+
+  for (let i = 0; i < sorted.length; i += 1) {
+    for (let j = i + 1; j < sorted.length; j += 1) {
+      if (new Date(sorted[i].end) <= new Date(sorted[j].start)) break;
+      const overlaps =
+        new Date(sorted[i].start) < new Date(sorted[j].end) &&
+        new Date(sorted[i].end) > new Date(sorted[j].start);
+      if (overlaps) {
+        conflicts.add(sorted[i].id);
+        conflicts.add(sorted[j].id);
+      }
+    }
+  }
+
+  return conflicts;
+};
 
 export function CalendarSchedule({ tasks }: { tasks: Task[] }) {
   const queryClient = useQueryClient();
@@ -19,25 +67,75 @@ export function CalendarSchedule({ tasks }: { tasks: Task[] }) {
     queryKey: ['timeblocks'],
     queryFn: fetchTimeBlocks,
   });
+  const { data: channels = [] } = useQuery({
+    queryKey: ['channels'],
+    queryFn: fetchChannels,
+  });
+  const { data: calendarStatus } = useQuery({
+    queryKey: ['calendarStatus'],
+    queryFn: fetchCalendarStatus,
+  });
+
+  const [selectedChannel, setSelectedChannel] = useState<'all' | string>('all');
+  const [defaultDuration, setDefaultDuration] = useState(DEFAULT_DURATION_MIN);
+  const [quickTitle, setQuickTitle] = useState('');
+  const [taskForBlocks, setTaskForBlocks] = useState<string | 'none'>('none');
+  const [channelName, setChannelName] = useState('');
+  const [channelColor, setChannelColor] = useState('#7c3aed');
+
+  const filteredBlocks = useMemo(
+    () =>
+      selectedChannel === 'all'
+        ? timeBlocks
+        : timeBlocks.filter((block) => block.channelId === selectedChannel),
+    [selectedChannel, timeBlocks]
+  );
+
+  const conflicts = useMemo(
+    () => findConflicts(filteredBlocks),
+    [filteredBlocks]
+  );
+
+  const createChannelMutation = useMutation({
+    mutationFn: createChannel,
+    onMutate: async (input) => {
+      await queryClient.cancelQueries({ queryKey: ['channels'] });
+      const previous = queryClient.getQueryData<Channel[]>(['channels']) ?? [];
+      const optimistic: Channel = { ...input, id: `temp-${Date.now()}` };
+      queryClient.setQueryData(['channels'], [...previous, optimistic]);
+      setChannelName('');
+      return { previous };
+    },
+    onError: (_error, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(['channels'], ctx.previous);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['channels'] }),
+  });
 
   const createMutation = useMutation({
     mutationFn: createTimeBlock,
     onMutate: async (input) => {
       await queryClient.cancelQueries({ queryKey: ['timeblocks'] });
-      const previous =
-        queryClient.getQueryData<TimeBlock[]>(['timeblocks']) ?? [];
-      const optimistic: TimeBlock = { ...input, id: `temp-${Date.now()}` };
+      const previous = queryClient.getQueryData<TimeBlock[]>(['timeblocks']) ?? [];
+      const optimistic: TimeBlock = {
+        status: input.status ?? 'tentative',
+        id: `temp-${Date.now()}`,
+        ...input,
+      };
       queryClient.setQueryData(['timeblocks'], [...previous, optimistic]);
+      setQuickTitle('');
       return { previous };
     },
-    onError: (_err, _vars, ctx) => {
+    onError: (err, _vars, ctx) => {
       if (ctx?.previous) queryClient.setQueryData(['timeblocks'], ctx.previous);
+      if (err instanceof Error) alert(err.message);
     },
     onSuccess: (block) =>
       trackEvent('timeblock.scheduled', {
         blockId: block.id,
         start: block.start,
         end: block.end,
+        channelId: block.channelId,
       }),
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: ['timeblocks'] }),
@@ -58,35 +156,84 @@ export function CalendarSchedule({ tasks }: { tasks: Task[] }) {
       );
       return { previous };
     },
-    onError: (_err, _vars, ctx) => {
+    onError: (err, _vars, ctx) => {
       if (ctx?.previous) queryClient.setQueryData(['timeblocks'], ctx.previous);
+      if (err instanceof Error) alert(err.message);
     },
     onSettled: () =>
       queryClient.invalidateQueries({ queryKey: ['timeblocks'] }),
   });
 
-  const events: EventInput[] = useMemo(
-    () =>
-      timeBlocks.map((block) => ({
+  const suggestMutation = useMutation({
+    mutationFn: suggestTimeBlock,
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['timeblocks'] });
+    },
+    onError: (err) => {
+      if (err instanceof Error) alert(err.message);
+    },
+    onSuccess: (_response, variables) => {
+      trackEvent('calendar.auto_schedule', {
+        taskId: variables.taskId,
+        durationMinutes: variables.durationMinutes,
+      });
+      queryClient.invalidateQueries({ queryKey: ['timeblocks'] });
+    },
+  });
+
+  const connectMutation = useMutation({
+    mutationFn: connectCalendar,
+    onSuccess: (status) => {
+      trackEvent('calendar.connected', { provider: status.provider });
+      queryClient.invalidateQueries({ queryKey: ['calendarStatus'] });
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: disconnectCalendar,
+    onSuccess: (status) => {
+      trackEvent('calendar.disconnected', { provider: status.provider });
+      queryClient.invalidateQueries({ queryKey: ['calendarStatus'] });
+    },
+  });
+
+  const pollMutation = useMutation({
+    mutationFn: pollCalendar,
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['calendarStatus'] });
+      queryClient.invalidateQueries({ queryKey: ['timeblocks'] });
+      trackEvent('calendar.synced', { synced: result.synced });
+    },
+  });
+
+  const events: EventInput[] = useMemo(() => {
+    return filteredBlocks.map((block) => {
+      const color = getChannelColor(block.channelId, channels);
+      const isConflict = conflicts.has(block.id);
+      return {
         id: block.id,
-        title: block.title,
+        title: `${block.title} · ${block.status}`,
         start: block.start,
         end: block.end,
-        backgroundColor: 'rgba(139, 92, 246, 0.9)',
+        backgroundColor: isConflict ? 'rgba(239, 68, 68, 0.85)' : color,
         borderColor: 'transparent',
-      })),
-    [timeBlocks]
-  );
+      };
+    });
+  }, [channels, conflicts, filteredBlocks]);
 
   const handleDateClick = (arg: DateClickArg) => {
-    const title = prompt('Name this focus block');
-    if (!title) return;
+    const selectedTask = tasks.find((task) => task.id === taskForBlocks);
+    const title = quickTitle.trim() || selectedTask?.title || 'Focus block';
     const start = arg.date;
-    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    const end = new Date(start.getTime() + defaultDuration * 60 * 1000);
+
     createMutation.mutate({
       start: start.toISOString(),
       end: end.toISOString(),
       title,
+      taskId: selectedTask?.id,
+      channelId: selectedChannel === 'all' ? undefined : selectedChannel,
+      status: 'tentative',
     });
   };
 
@@ -101,18 +248,254 @@ export function CalendarSchedule({ tasks }: { tasks: Task[] }) {
     });
   };
 
+  const handleEventClick = (arg: EventClickArg) => {
+    const block = timeBlocks.find((item) => item.id === arg.event.id);
+    if (!block) return;
+
+    updateMutation.mutate({
+      id: block.id,
+      patch: { status: nextStatus(block.status) },
+    });
+  };
+
+  const handleAutoSchedule = () => {
+    if (taskForBlocks === 'none') {
+      alert('Select a task to auto-schedule');
+      return;
+    }
+
+    const selectedTask = tasks.find((task) => task.id === taskForBlocks);
+    if (!selectedTask) return;
+
+    suggestMutation.mutate({
+      taskId: selectedTask.id,
+      title: selectedTask.title,
+      durationMinutes: defaultDuration,
+      channelId: selectedChannel === 'all' ? null : selectedChannel,
+    });
+  };
+
   return (
     <div className="section-card">
       <header className="section-header">
         <div>
           <p className="helper-text">Calendar</p>
           <h2 className="section-title">Schedule</h2>
+          <p className="helper-text">
+            Drag blocks, resize them, and switch channels to timebox your day.
+          </p>
         </div>
-        <p className="helper-text">
-          Drag blocks or click to schedule focus time · {tasks.length} tasks
-          cached
-        </p>
+        <div className="grid-two-col" style={{ gap: 10, maxWidth: 420 }}>
+          <div>
+            <label className="helper-text" htmlFor="channel-view-select">
+              Channel view
+            </label>
+            <select
+              id="channel-view-select"
+              value={selectedChannel}
+              onChange={(e) => setSelectedChannel(e.target.value)}
+              className="section-card"
+              style={{ padding: '10px 12px', width: '100%' }}
+              aria-label="Filter calendar by channel"
+            >
+              <option value="all">All channels</option>
+              {channels.map((channel) => (
+                <option key={channel.id} value={channel.id}>
+                  {channel.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <Input
+              label="Default duration (minutes)"
+              type="number"
+              min={15}
+              value={defaultDuration}
+              onChange={(e) => setDefaultDuration(Number(e.target.value))}
+            />
+          </div>
+        </div>
       </header>
+
+      <div
+        className="section-card"
+        style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}
+      >
+        <div style={{ flex: 1 }}>
+          <p className="helper-text">Sync</p>
+          <h3 style={{ margin: 0 }}>Google Calendar</h3>
+          <p className="helper-text" role="status" aria-live="polite">
+            Status: {calendarStatus?.status ?? 'checking'}
+            {calendarStatus?.lastSyncedAt &&
+              ` · Last sync ${new Date(calendarStatus.lastSyncedAt).toLocaleString()}`}
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {calendarStatus?.status === 'connected' ? (
+            <Button
+              variant="secondary"
+              onClick={() => disconnectMutation.mutate()}
+              disabled={disconnectMutation.isPending}
+              aria-label="Disconnect Google Calendar"
+            >
+              Disconnect
+            </Button>
+          ) : (
+            <Button
+              onClick={() => connectMutation.mutate()}
+              disabled={connectMutation.isPending}
+              aria-label="Connect Google Calendar"
+            >
+              Connect
+            </Button>
+          )}
+          <Button
+            onClick={() => pollMutation.mutate()}
+            disabled={pollMutation.isPending || calendarStatus?.status !== 'connected'}
+            aria-label="Sync calendar events now"
+          >
+            Sync now
+          </Button>
+        </div>
+      </div>
+
+      {conflicts.size > 0 && (
+        <div
+          className="section-card"
+          style={{
+            background: 'rgba(239, 68, 68, 0.08)',
+            borderColor: 'rgba(239, 68, 68, 0.25)',
+            marginBottom: 12,
+          }}
+        >
+          <p className="helper-text" style={{ color: '#fca5a5' }}>
+            {conflicts.size} block(s) overlap. Drag to resolve or shorten them.
+          </p>
+        </div>
+      )}
+
+      <div
+        className="section-card"
+        style={{
+          marginBottom: 14,
+          display: 'grid',
+          gridTemplateColumns: '1.5fr 1fr 1fr auto',
+          gap: 10,
+          alignItems: 'end',
+        }}
+      >
+        <Input
+          label="Block title"
+          placeholder="Deep work, backlog triage..."
+          value={quickTitle}
+          onChange={(e) => setQuickTitle(e.target.value)}
+        />
+        <label className="helper-text" style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          Task to timebox
+          <select
+            value={taskForBlocks}
+            onChange={(e) => setTaskForBlocks(e.target.value as string | 'none')}
+            className="section-card"
+            style={{ padding: '10px 12px' }}
+          >
+            <option value="none">Unassigned block</option>
+            {tasks.map((task) => (
+              <option key={task.id} value={task.id}>
+                {task.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="helper-text" style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          Channel
+          <select
+            id="channel-for-blocks"
+            value={selectedChannel}
+            onChange={(e) => setSelectedChannel(e.target.value)}
+            className="section-card"
+            style={{ padding: '10px 12px' }}
+            aria-label="Channel for the new time block"
+          >
+            <option value="all">Use default channel</option>
+            {channels.map((channel) => (
+              <option key={channel.id} value={channel.id}>
+                {channel.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Button
+            onClick={() => alert('Click on the calendar to drop the block')}
+            aria-label="Pick a slot on the calendar"
+          >
+            Pick a slot
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={handleAutoSchedule}
+            disabled={suggestMutation.isPending}
+          >
+            Auto-schedule
+          </Button>
+        </div>
+      </div>
+
+      <div className="section-card" style={{ marginBottom: 14 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <p className="helper-text">Channels</p>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              {channels.map((channel) => (
+                <span
+                  key={channel.id}
+                  className="badge"
+                  data-tone="info"
+                  style={{
+                    background: `${channel.color ?? 'rgba(255,255,255,0.08)'}`,
+                    color: '#0f172a',
+                  }}
+                >
+                  {channel.name}
+                </span>
+              ))}
+            </div>
+          </div>
+          <form
+            style={{ display: 'flex', alignItems: 'flex-end', gap: 8 }}
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!channelName.trim()) return;
+              createChannelMutation.mutate({
+                userId: 'f1c3b317-1111-4b0c-9b44-2b2fd0d3f111',
+                name: channelName.trim(),
+                visibility: 'private',
+                color: channelColor,
+              });
+            }}
+          >
+            <Input
+              label="New channel"
+              value={channelName}
+              onChange={(e) => setChannelName(e.target.value)}
+              placeholder="Focus, meetings, personal"
+            />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span className="helper-text">Color</span>
+              <input
+                type="color"
+                aria-label="Channel color"
+                value={channelColor}
+                onChange={(e) => setChannelColor(e.target.value)}
+                style={{ width: 64, height: 38, borderRadius: 10, border: '1px solid rgba(255,255,255,0.15)' }}
+              />
+            </div>
+            <Button type="submit">Add</Button>
+          </form>
+        </div>
+      </div>
+
       <FullCalendar
         plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
         initialView="timeGridWeek"
@@ -128,6 +511,7 @@ export function CalendarSchedule({ tasks }: { tasks: Task[] }) {
         dateClick={handleDateClick}
         eventDrop={handleDrop}
         eventResize={handleDrop}
+        eventClick={handleEventClick}
         height="auto"
         slotMinTime="07:00:00"
         slotMaxTime="20:00:00"

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -6,7 +6,11 @@ export type TelemetryEventName =
   | 'planning_session.completed'
   | 'highlight.created'
   | 'objective.created'
-  | 'break.scheduled';
+  | 'break.scheduled'
+  | 'calendar.connected'
+  | 'calendar.disconnected'
+  | 'calendar.synced'
+  | 'calendar.auto_schedule';
 
 export function trackEvent(
   name: TelemetryEventName,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,12 +10,35 @@ export type Task = {
   dueDate?: string;
 };
 
+export type TimeBlockStatus =
+  | 'tentative'
+  | 'confirmed'
+  | 'completed'
+  | 'cancelled';
+
 export type TimeBlock = {
   id: string;
   title: string;
   taskId?: string;
+  channelId?: string | null;
   start: string;
   end: string;
+  status: TimeBlockStatus;
+  location?: string;
+  notes?: string;
+  provider?: 'google' | 'ical' | 'local';
+  calendarEventId?: string | null;
+};
+
+export type ChannelVisibility = 'private' | 'shared';
+
+export type Channel = {
+  id: string;
+  userId: string;
+  name: string;
+  visibility: ChannelVisibility;
+  targetCalendarId?: string | null;
+  color?: string | null;
 };
 
 export type PlanningSessionType = 'morning' | 'evening' | 'weekly' | 'custom';
@@ -32,6 +55,7 @@ export type PlanningSession = {
   completedAt?: string;
   reflection?: string;
   highlightId?: string;
+  plannedTaskIds?: string[];
   objectiveIds?: string[];
 };
 
@@ -63,6 +87,7 @@ export type FocusSession = {
   status: 'active' | 'completed';
   startedAt?: string;
   completedAt?: string;
+  interruptions?: number;
 };
 
 export type ScheduledBreak = {
@@ -73,4 +98,13 @@ export type ScheduledBreak = {
   start: string;
   end: string;
   reminderSent: boolean;
+};
+
+export type CalendarIntegrationStatus = {
+  provider: 'google';
+  status: 'connected' | 'disconnected';
+  integrationId?: string;
+  syncMode?: 'polling' | 'webhook';
+  lastSyncedAt?: string | null;
+  calendarId?: string | null;
 };


### PR DESCRIPTION
## Summary
- add a daily digest job plus telemetry helpers to summarize due tasks and stale calendar syncs
- record audit logs and telemetry events for task mutations and calendar actions
- improve calendar UI accessibility and sync controls with telemetry coverage

## Testing
- npm test --workspace backend
- npm test --workspace frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1b13912483319cc1d4444c277b3b)